### PR TITLE
setup: Add options to install tensorflow-macos if running on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ We refer to the [TensorFlow GPU support tutorial](https://www.tensorflow.org/ins
 ### Installation using pip
 
 We recommend to do this within a [virtual environment](https://docs.python.org/3/tutorial/venv.html), e.g., using [conda](https://docs.conda.io).
+On macOS, you need to install [tensorflow-macos](https://github.com/apple/tensorflow_macos) first.
 
 1.) Install the package
 ```

--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -15,7 +15,9 @@ Although not necessary, we recommend running Sionna in a `Docker container <http
 Installation using pip
 ----------------------
 We recommend to do this within a `virtual environment <https://docs.python.org/3/tutorial/venv.html>`_,
-e.g., using `conda <https://docs.conda.io>`_.
+e.g., using `conda <https://docs.conda.io>`_. On macOS, you need to install `tensorflow-macos <https://github.com/apple/tensorflow_macos>`_ first.
+
+
 
 
 1.) Install the package

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
-tensorflow>=2.5, <=2.8
+tensorflow>=2.5, <=2.8 ; sys_platform != "darwin"
+tensorflow-macos >= 2.5, <= 2.8 ; sys_platform == "darwin"
 numpy
 scipy
 matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,8 @@ include_package_data = True
 python_requires = >=3.6
 
 install_requires =
-    tensorflow >= 2.5
+    tensorflow >= 2.5; sys_platform != "darwin"
+    tensorflow-macos; sys_platform == "darwin"
     numpy
     matplotlib
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ include_package_data = True
 python_requires = >=3.6
 
 install_requires =
-    tensorflow >= 2.5; sys_platform != "darwin"
-    tensorflow-macos >= 2.5; sys_platform == "darwin"
+    tensorflow >= 2.5, <= 2.8 ; sys_platform != "darwin"
+    tensorflow-macos >= 2.5, <= 2.8 ; sys_platform == "darwin"
     numpy
     matplotlib
     scipy

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ python_requires = >=3.6
 
 install_requires =
     tensorflow >= 2.5; sys_platform != "darwin"
-    tensorflow-macos; sys_platform == "darwin"
+    tensorflow-macos >= 2.5; sys_platform == "darwin"
     numpy
     matplotlib
     scipy


### PR DESCRIPTION
Currently the tensorflow package is not available for macOS und when attempting to install on macOS
an error is thrown. Instead let pip check the platform and select the correct tensorflow package called
tensorflow-macos.

Signed-off-by: Andrej Rode <rode@kit.edu>


## Description

Adds a conditional into setup.cfg to check & select the correct tensorflow package for macOS.

- Fixes a bug?

Allows installs with macOS without errors.

