### PR TITLE
fix: set marker for antenna based on polarization

### DIFF
--- a/sionna/channel/tr38901/antenna.py
+++ b/sionna/channel/tr38901/antenna.py
@@ -10,6 +10,7 @@ from tensorflow import sin, cos, sqrt
 import numpy as np
 
 import matplotlib.pyplot as plt
+from matplotlib.markers import MarkerStyle
 
 from sionna import SPEED_OF_LIGHT, PI
 from sionna.utils import log10
@@ -612,16 +613,24 @@ class PanelArray:
 
     def show(self):
         """Show the panel array geometry"""
+        marker_vert = MarkerStyle("|")
+        marker_horz = MarkerStyle("_")
+        if self._polarization == 'single' and self._polarization_type == 'H':
+            marker_vert = marker_horz
+        elif self._polarization == 'dual' and self._polarization_type == 'cross':
+            marker_vert._transform.rotate_deg(-45)      # pylint: disable=protected-access
+            marker_horz._transform.rotate_deg(-45)      # pylint: disable=protected-access
+
         fig = plt.figure()
         pos_pol1 = self._ant_pos_pol1
-        plt.plot(pos_pol1[:,1], pos_pol1[:,2], marker = "|",
+        plt.plot(pos_pol1[:,1], pos_pol1[:,2], marker = marker_vert,
             markeredgecolor='red', markersize="20", linestyle="None",
             markeredgewidth="2")
         for i, p in enumerate(pos_pol1):
             fig.axes[0].annotate(self._ant_ind_pol1[i].numpy()+1, (p[1], p[2]))
         if self._polarization == 'dual':
             pos_pol2 = self._ant_pos_pol2
-            plt.plot(pos_pol2[:,1], pos_pol2[:,2], marker = "_",
+            plt.plot(pos_pol2[:,1], pos_pol2[:,2], marker = marker_horz,
                 markeredgecolor='black', markersize="20", linestyle="None",
                 markeredgewidth="1")
         plt.xlabel("y (m)")


### PR DESCRIPTION
When plotting the panel geomerty, set the marker for antenna based on
the polarization type. The following markers are now used for different
polarization types:
single vertical polarization: "|"
single horizontal polarization: "_"
dual "VH" polarization: "|" & "_"
dual "cross" polarization: "|" & "_" rotated by -45 degrees

Signed-off-by: Ebin Chacko <eby193@gmail.com>


## Description

A clear and concise description of what this pull request does.

- Fixes a bug?

Describe what was wrong, and explain the solution in detail.

- Adds a new feature?

Describe the new feature, ensure that it is properly documented. Note that for new features unit tests are required.

- Introduces API changes?

Address in detail why it is needed. Explain and describe the consequences, does it break older code? Note that API changes might be delayed until a major bump release for inclusion.

- Other contributions

Please detail the nature of the submission.


## Checklist

[ ] Detailed description
[ ] Added references to issues and discussions
[ ] Added / modified documentation as needed
[ ] Added / modified unit tests as needed
[ ] Passes all tests
[ ] Lint the code
[ ] Performed a self review
[ ] Ensure you Signed-off the commits. Required to accept contributions!
[ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
