### PR TITLE
setup: allow tensorflow versions 2.8.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-tensorflow>=2.5, <=2.8 ; sys_platform != "darwin"
-tensorflow-macos >= 2.5, <= 2.8 ; sys_platform == "darwin"
+tensorflow>=2.5, < 2.9 ; sys_platform != "darwin"
+tensorflow-macos >= 2.5, < 2.9 ; sys_platform == "darwin"
 numpy
 scipy
 matplotlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ include_package_data = True
 python_requires = >=3.6
 
 install_requires =
-    tensorflow >= 2.5, <= 2.8 ; sys_platform != "darwin"
-    tensorflow-macos >= 2.5, <= 2.8 ; sys_platform == "darwin"
+    tensorflow >= 2.5, < 2.9 ; sys_platform != "darwin"
+    tensorflow-macos >= 2.5, < 2.9 ; sys_platform == "darwin"
     numpy
     matplotlib
     scipy


### PR DESCRIPTION
## Description

The requirements syntax is a bit quirky: `tensorflow <= 2.8` means that the maximum supported is `2.8.0`. This patch should allow to install versions like `2.8.2`, which introduced some fixes.