### PR TITLE
fix: calculation of step noise in SSFM

### DIFF
--- a/sionna/channel/optical/fiber.py
+++ b/sionna/channel/optical/fiber.py
@@ -237,25 +237,21 @@ class SSFM(Layer):
     def _apply_noise(self, q, dz):
         # Noise due to Amplification (Raman)
         if self._with_amplification:
+            step_noise = self._p_n_ase * tf.cast(dz, self._rdtype) / tf.cast(self._length, self._rdtype) / tf.cast(
+                2.0, self._rdtype)
             q_n = tf.complex(
                 tf.random.normal(
                     q.shape,
                     tf.cast(0.0, self._rdtype),
                     tf.sqrt(
-                        self._p_n_ase *
-                        tf.cast(dz, self._rdtype) /
-                        tf.cast(self._length, self._rdtype) /
-                        tf.cast(2.0, self._rdtype)
+                        step_noise
                     ),
                     self._rdtype),
                 tf.random.normal(
                     q.shape,
                     tf.cast(0.0, self._rdtype),
                     tf.sqrt(
-                        self._p_n_ase /
-                        tf.cast(dz, self._rdtype) /
-                        tf.cast(self._length, self._rdtype) /
-                        tf.cast(2.0, self._rdtype)
+                        step_noise
                     ),
                     self._rdtype
                 )


### PR DESCRIPTION
## Description

Fixes the calculation of the amplifier noise applied in each step of the SSFM if the Raman amplifier is used. The calculation for the noise power of the imaginary part was incorrect, since a division was used instead of a multiplication. To further simplify the code, the calculation of the noise power is only done once per step.


## Checklist

- [x] Detailed description
- [ ] Added references to issues and discussions
- [x] Added / modified documentation as needed
- [x] Added / modified unit tests as needed
- [x] Passes all tests
- [x] Lint the code
- [x] Performed a self review
- [x] Ensure you Signed-off the commits. Required to accept contributions!
- [ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
