### PR TITLE
Migrate to jupyter lab. Fix scene.preview() issue

### DIFF
--- a/DOCKERFILE
+++ b/DOCKERFILE
@@ -4,10 +4,10 @@ COPY . /tmp/
 WORKDIR /tmp/
 RUN make install
 RUN apt-get install llvm -y
-RUN pip install --upgrade jupyter
 RUN pip install --upgrade ipykernel
+RUN pip install --upgrade jupyterlab
 RUN rm -R /tf/* && cp /tmp/examples/* /tf
 RUN rm -R /tmp
 RUN chmod 777 -R /tf
 WORKDIR /tf
-CMD ["jupyter", "notebook", "--port=8888", "--no-browser", "--NotebookApp.token=''", "--ip=0.0.0.0", "--allow-root", "--NotebookApp.allow_origin='*'"]
+CMD ["jupyter", "lab", "--port=8888", "--no-browser", "--NotebookApp.token=''", "--ip=0.0.0.0", "--allow-root", "--NotebookApp.allow_origin='*'"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ mitsuba >= 3.2.0
 pythreejs >= 2.4.2
 ipywidgets >= 8.0.4
 ipydatawidgets == 4.3.2
+jupyterlab-widgets == 3.0.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     pythreejs >= 2.4.2
     ipywidgets >= 8.0.4
     ipydatawidgets == 4.3.2
+    jupyterlab-widgets == 3.0.5
 
 [options.package_data]
 * = *.csv, *.npy, *.json, *.xml, *.ply


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

- Bug fix 

This PR fixes consistent issues with the `scene.preview()` call used across various example notebooks. (#129 , #106). The issue existed even for the docker build. Closes #129.

The problem causes are:
1. Need to use jupyter lab (jupyter notebook does not work)
2. `jupyterlab-widgets` needs to be 3.0.5 

The fixes are:
1. Made changes to `DOCKERFILE` to use jupyter lab
2. Update requirements.txt and `setup.cfg` and freeze `jupyterlab-widgets` version

These changes allow the docker image to work out of the box. In line with the advice on #122, I've kept the modifications to a bare minimum. 

## Checklist

[x] Detailed description
[x] Added references to issues and discussions
~~[ ] Added / modified documentation as needed~~
~~[ ] Added / modified unit tests as needed~~
~~[ ] Passes all tests~~
[x] Lint the code
[x] Performed a self review
[x] Ensure you Signed-off the commits. Required to accept contributions!
~~[ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.~~
