### PR TITLE
fix(lib): wrong ValueError message

### DIFF
--- a/sionna/rt/antenna.py
+++ b/sionna/rt/antenna.py
@@ -54,7 +54,7 @@ class Antenna:
                 ):
 
         if dtype not in (tf.complex64, tf.complex128):
-            raise ValueError("`dtype` must be tf.complex64 or tf.complex64`")
+            raise ValueError("`dtype` must be tf.complex64 or tf.complex128`")
         self._dtype = dtype = dtype
 
         # Pattern is provided as string
@@ -157,7 +157,7 @@ def compute_gain(pattern, dtype=tf.complex64):
     """
 
     if dtype not in (tf.complex64, tf.complex128):
-        raise ValueError("`dtype` must be tf.complex64 or tf.complex64`")
+        raise ValueError("`dtype` must be tf.complex64 or tf.complex128`")
 
     # Create angular meshgrid
     theta = tf.linspace(0.0, PI, 1810)

--- a/sionna/rt/antenna_array.py
+++ b/sionna/rt/antenna_array.py
@@ -47,7 +47,7 @@ class AntennaArray():
         super().__init__()
 
         if dtype not in (tf.complex64, tf.complex128):
-            raise ValueError("`dtype` must be tf.complex64 or tf.complex64`")
+            raise ValueError("`dtype` must be tf.complex64 or tf.complex128`")
         self._rdtype = dtype.real_dtype
 
         self.antenna = antenna
@@ -206,7 +206,7 @@ class PlanarArray(AntennaArray):
                  dtype=tf.complex64):
 
         if dtype not in (tf.complex64, tf.complex128):
-            raise ValueError("`dtype` must be tf.complex64 or tf.complex64`")
+            raise ValueError("`dtype` must be tf.complex64 or tf.complex128`")
 
         # Create list of antennas
         array_size = num_rows*num_cols

--- a/sionna/rt/paths_2_cir.py
+++ b/sionna/rt/paths_2_cir.py
@@ -330,7 +330,7 @@ class Paths2CIR(Layer):
                        dtype=tf.complex64):
 
         if dtype not in (tf.complex64, tf.complex128):
-            raise ValueError("`dtype` must be tf.complex64 or tf.complex64`")
+            raise ValueError("`dtype` must be tf.complex64 or tf.complex128`")
 
         if scene is not None:
             if not isinstance(scene, Scene):

--- a/sionna/rt/radio_device.py
+++ b/sionna/rt/radio_device.py
@@ -66,7 +66,7 @@ class RadioDevice(OrientedObject):
                  dtype=tf.complex64):
 
         if dtype not in (tf.complex64, tf.complex128):
-            raise ValueError("`dtype` must be tf.complex64 or tf.complex64`")
+            raise ValueError("`dtype` must be tf.complex64 or tf.complex128`")
         self._dtype = dtype
         self._rdtype = dtype.real_dtype
 

--- a/sionna/rt/scene.py
+++ b/sionna/rt/scene.py
@@ -107,7 +107,7 @@ class Scene:
         if env_filename:
 
             if dtype not in (tf.complex64, tf.complex128):
-                msg = "`dtype` must be tf.complex64 or tf.complex64`"
+                msg = "`dtype` must be tf.complex64 or tf.complex128`"
                 raise ValueError(msg)
             self._dtype = dtype
             self._rdtype = dtype.real_dtype

--- a/sionna/rt/solver_base.py
+++ b/sionna/rt/solver_base.py
@@ -65,7 +65,7 @@ class SolverBase:
         #    _prim_offsets
 
         assert dtype in (tf.complex64, tf.complex128),\
-            "`dtype` must be tf.complex64 or tf.complex64`"
+            "`dtype` must be tf.complex64 or tf.complex128`"
         self._dtype = dtype
         self._rdtype = dtype.real_dtype
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Fixes a typo in multiple error messages where the complex dtype is duplicated.

- Fixes a bug?

There is a typo in multiple occurences of the same `ValueError` message, fixed it.

Occurrences were found using `ripgrep`:

```
rg -l "complex64 or tf.complex64" | xargs -n 1 sed -i "s/complex64 or tf.complex64/complex64 or tf.complex128/g"
```


## Checklist

[x] Detailed description
~~[ ] Added references to issues and discussions~~
~~[ ] Added / modified documentation as needed~~
~~[ ] Added / modified unit tests as needed~~
[x] Passes all tests
[x] Lint the code
[x] Performed a self review
[x] Ensure you Signed-off the commits. Required to accept contributions!
~~[ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.~~
