### PR TITLE
fixed tracking of column swaps and also adjusted column swaps when ma…

### DIFF
--- a/sionna/fec/utils.py
+++ b/sionna/fec/utils.py
@@ -984,7 +984,8 @@ def make_systematic(mat, is_pcm=False):
                     break
 
         if not found_1:
-            raise ValueError(f"failed to transform matrix to systematic form, because it is not of full rank")
+            raise ValueError("Failed to transform matrix to systematic"\
+                             "form. Is matrix of full rank?")
 
         # we can now assume a leading "1" at row idx_c
         for idx_r in range(idx_c+1, m):

--- a/sionna/fec/utils.py
+++ b/sionna/fec/utils.py
@@ -962,30 +962,29 @@ def make_systematic(mat, is_pcm=False):
 
     # bring in upper triangular form
     for idx_c in range(m):
-        success = False
-        # step 1: find next leading "1"
-        for idx_r in range(idx_c,m):
-            # skip if entry is "0"
-            if mat[idx_r, idx_c]:
-                mat[[idx_c, idx_r]] = mat[[idx_r, idx_c]] # swap rows
-                success = True
-                break
+        found_1 = mat[idx_c, idx_c]
 
-        # Could not find "1"-entry for column idx_c
-        # => swap with columns from non-sys part
-        # The task is to find a column with index idx_cc that has a "1" at
-        # row idx_c
-        if not success:
+        if not found_1:
+            # find a row below row idx_c that has a "1" at column idx_c
+            for idx_r in range(idx_c+1, m):
+                if mat[idx_r, idx_c]:
+                    # swap rows
+                    mat[[idx_c, idx_r]] = mat[[idx_r, idx_c]]
+                    found_1 = True
+                    break
+
+        if not found_1:
+            # find a column after current column that has a "1" at row idx_c
             for idx_cc in range(idx_c+1, n):
                 if mat[idx_c, idx_cc]:
                     # swap columns
                     mat[:,[idx_c, idx_cc]] = mat[:,[idx_cc, idx_c]]
                     column_swaps.append([idx_c, idx_cc])
-                    success=True
+                    found_1 = True
                     break
 
-        if not success:
-            raise ValueError("Could not succeed; mat is not full rank?")
+        if not found_1:
+            raise ValueError(f"failed to transform matrix to systematic form, because it is not of full rank")
 
         # we can now assume a leading "1" at row idx_c
         for idx_r in range(idx_c+1, m):

--- a/sionna/fec/utils.py
+++ b/sionna/fec/utils.py
@@ -976,7 +976,7 @@ def make_systematic(mat, is_pcm=False):
         # The task is to find a column with index idx_cc that has a "1" at
         # row idx_c
         if not success:
-            for idx_cc in range(m, n):
+            for idx_cc in range(idx_c+1, n):
                 if mat[idx_c, idx_cc]:
                     # swap columns
                     mat[:,[idx_c, idx_cc]] = mat[:,[idx_cc, idx_c]]

--- a/sionna/fec/utils.py
+++ b/sionna/fec/utils.py
@@ -1004,12 +1004,10 @@ def make_systematic(mat, is_pcm=False):
 
     # bring identity part to end of matrix if parity-check matrix is provided
     if is_pcm:
-        im = np.copy(mat[:,:m])
-        mat[:,:m] = mat[:,-m:]
-        mat[:,-m:] = im
-        # and track column swaps
-        for idx in range(m):
-            column_swaps.append([idx, n-m+idx])
+        for i in range(n-1, (n-1)-m, -1):
+            j = i - (n-m)
+            mat[:,[i, j]] = mat[:,[j, i]]
+            column_swaps.append([i, j])
 
     # return integer array
     mat = mat.astype(int)


### PR DESCRIPTION
…king an FEC matrix systematic

<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

bugfix pull request to fix one bug.

### Fixed Bug
the problem that shall be fixed is a wrong tracking of the column swaps behind a call to sionna.fec.utils.pcm2gm, more specifically in sionna.fec.utils.make_systematic . there, parts of a matrix get swapped correctly, but the tracked column swaps do not reflect the swaps actually performed. the swap-tracking is wrong. this is easy to see when using sionna.fec.utils.pcm2gm and telling it to check its own result for correctness. it fails for certain cases. one such case is in the below file, which is a minimum runnable example that demonstrates the bug:  
https://github.com/daniel-x/sionna_daniel-x/blob/fix_column_swap_tracking_demo/bug_demo_pcm2gm_wrong_column_swap_tracking.py  
(the bug demo is intentionally NOT part of the pull request, because it shall not end up in the main branch)

### Solution
the current version with the bug does a blockwise swap of matrix regions. it is not straightforward to see how to reflect this with individual column swaps (though it is possible). this was likely the reason for the bug.  
the solution replaces the blockwise swap of matrix regions by individual column swaps and tracks all swaps correctly. this has 3 effects:  
1. the performed column swaps get tracked correctly and the result is valid for more input samples  
2. less memory usage, because there is no more need to keep temporary copies of matrix regions in memory  
3. the exact result before and after this bugfix is different, because the column rearrangement strategy is changed. however, the result is still valid, because as long as the column reordering is tracked correctly and the matrix regions as a whole are swapped, the result is valid.  

Point 3. might break tests, although the result is still valid. In this case, the tests need to be examined carefully and adjusted if the results are still correct.

### Necessity for the change

The code currently fails to calculate the correct generator matrices for valid check matrices of certain kinds. This makes it hard to test other error correction codes and compare them using sionna, making interoperability a burden, hence users might switch to other tools or libraries or cause confusion. To make sionna more usable, the change should be pulled.

## Checklist

[+] Detailed description
[-] Added references to issues and discussions
[-] Added / modified documentation as needed
[-] Added / modified unit tests as needed
[ ] Passes all tests
[+] Lint the code
[+] Performed a self review
[ ] Ensure you Signed-off the commits. Required to accept contributions!
[-] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
