### PR TITLE
Add min_bler and callback to sim_ber

### DIFF
--- a/sionna/utils/misc.py
+++ b/sionna/utils/misc.py
@@ -416,9 +416,11 @@ def sim_ber(mc_fun,
     """Simulates until target number of errors is reached and returns BER/BLER.
 
     The simulation continues with the next SNR point if either
-    ``num_target_bit_errors`` bit errors or ``num_target_block_errors`` block
-    errors is achieved. Further, it continues with the next SNR point after
-    ``max_mc_iter`` batches of size ``batch_size`` have been simulated.
+    ``num_target_bit_errors`` bit errors or
+    ``num_target_block_errors`` block errors is achieved or
+    ``min_ber`` is satisfied. Further, it continues with the next SNR
+    point after ``max_mc_iter`` batches of size ``batch_size`` have
+    been simulated.
 
     Input
     -----
@@ -450,6 +452,9 @@ def sim_ber(mc_fun,
         Defaults to None. Target number of block errors per SNR point
         until the simulation continues
 
+    min_bler: tf.float32 Defaults to None.  Stop simulation if
+        previous ebno iteration produced bler less than this amount.
+    
     early_stop: bool
         A boolean defaults to True. If True, the simulation stops after the
         first error-free SNR point (i.e., no error occurred after
@@ -472,6 +477,12 @@ def sim_ber(mc_fun,
     dtype: tf.complex64
         Datatype of the model / function to be used (``mc_fun``).
 
+    callback: function Defaults to None.  If specified, a function
+        that will be called after each simulation block and passed the
+        results, which could be used for logging in a long-running
+        simulation. Signature: callback (ebno_dbs, bit_errors,
+        block_errors, nb_bits, nb_blocks)
+    
     Output
     ------
     (ber, bler) :


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

This adds 2 features to sim_ber function. 
1.  Add min_bler stopping feature.  Similar to early_stop, if the BLER on the previous ebno step was less than some value then stop.  This is useful if, for example, you only want to simulate down to 1e-5.
2. Add callback.  This will call a callback function at each iteration, which can be used for logging, for example. 
- Fixes a bug?

Describe what was wrong, and explain the solution in detail.

- Adds a new feature?

Yes

Describe the new feature, ensure that it is properly documented. Note that for new features unit tests are required.

- Introduces API changes?
No

Address in detail why it is needed. Explain and describe the consequences, does it break older code? Note that API changes might be delayed until a major bump release for inclusion.

This is a non-breaking addition which will help with long-running simulations.

- Other contributions

Please detail the nature of the submission.


## Checklist

[x ] Detailed description
[ ] Added references to issues and discussions
[ ] Added / modified documentation as needed
[ ] Added / modified unit tests as needed
[ ] Passes all tests
[ ] Lint the code
[ ] Performed a self review
[ x] Ensure you Signed-off the commits. Required to accept contributions!
[ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
