### PR TITLE
User defined colors for receiver/transmitter points in render/preview #256

### DIFF
--- a/sionna/rt/previewer.py
+++ b/sionna/rt/previewer.py
@@ -122,15 +122,14 @@ class InteractiveDisplay:
         """
         scene = self._scene
         sc, tx_positions, rx_positions, _ = scene_scale(scene)
-        tr_color = [0.160, 0.502, 0.725]
-        rc_color = [0.153, 0.682, 0.375]
-
+        transmitter_colors = [[val/255 for val in transmitter.color] for 
+                              transmitter in scene.transmitters.values()]
+        receiver_colors = [[val/255 for val in receiver.color] for 
+                           receiver in scene.receivers.values()]
+        
         # Radio emitters, shown as points
         p = np.array(list(tx_positions.values()) + list(rx_positions.values()))
-        albedo = np.array(
-            [tr_color] * len(scene.transmitters)
-            + [rc_color] * len(scene.receivers)
-        )
+        albedo = np.array(transmitter_colors + receiver_colors)
 
         if p.shape[0] > 0:
             # Radio devices are not persistent
@@ -142,14 +141,13 @@ class InteractiveDisplay:
             head_length = 0.15 * line_length
             zeros = np.zeros((1, 3))
 
-            for devices, color in [(scene.transmitters.values(), tr_color),
-                                   (scene.receivers.values(), rc_color)]:
+            for devices in [scene.transmitters.values(),scene.receivers.values()]:
                 if len(devices) == 0:
                     continue
-                color = f'rgb({", ".join([str(int(v * 255)) for v in color])})'
                 starts, ends = [], []
                 for rd in devices:
                     # Arrow line
+                    color = f'rgb({", ".join([str(int(v)) for v in rd.color])})'
                     starts.append(rd.position)
                     endpoint = rd.position + rotate([line_length, 0., 0.],
                                                     rd.orientation)

--- a/sionna/rt/radio_device.py
+++ b/sionna/rt/radio_device.py
@@ -43,6 +43,9 @@ class RadioDevice(OrientedObject):
         :class:`~sionna.rt.Receiver`, or :class:`~sionna.rt.Camera` to look at.
         If set to `None`, then ``orientation`` is used to orientate the device.
 
+    color : [3], integer
+        Defines the RGB ``color`` for the device shown in the previewer or renderer.
+
     trainable_position : bool
         Determines if the ``position`` is a trainable variable or not.
         Defaults to `False`.
@@ -61,6 +64,7 @@ class RadioDevice(OrientedObject):
                  position,
                  orientation=(0.,0.,0.),
                  look_at=None,
+                 color=(0,0,0),
                  trainable_position=False,
                  trainable_orientation=False,
                  dtype=tf.complex64):
@@ -72,6 +76,8 @@ class RadioDevice(OrientedObject):
 
         self._position = tf.Variable(tf.zeros([3], self._rdtype))
         self._orientation = tf.Variable(tf.zeros([3], self._rdtype))
+
+        self._color = color
 
         self.trainable_position = trainable_position
         self.trainable_orientation = trainable_orientation
@@ -183,3 +189,18 @@ class RadioDevice(OrientedObject):
         beta = theta-PI/2 # Rotation around y-axis
         gamma = 0.0 # Rotation around x-axis
         self.orientation = (alpha, beta, gamma)
+
+    @property
+    def color(self):
+        """
+        [3], tf.integer : Get/set the color
+        """
+        return self._color
+
+    @color.setter
+    def color(self, new_color):
+        new_color = tf.cast(new_color, dtype=self._rdtype)
+        if not (tf.rank(new_color) == 1 and new_color.shape[0] == 3):
+            msg = "Color must be shaped as [r,g,b] (rank=1 and shape=[3])"
+            raise ValueError(msg)
+        self._color.assign(new_color)

--- a/sionna/rt/receiver.py
+++ b/sionna/rt/receiver.py
@@ -34,6 +34,10 @@ class Receiver(RadioDevice):
         :class:`~sionna.rt.Receiver`, or :class:`~sionna.rt.Camera` to look at.
         If set to `None`, then ``orientation`` is used to orientate the device.
 
+    color : [3], integer
+        Defines the rgb ``color`` for the device shown in the previewer or renderer.
+        Default RGB value for the receiver is (39, 173, 95).
+
     trainable_position : bool
         Determines if the ``position`` is a trainable variable or not.
         Defaults to `False`.
@@ -52,6 +56,7 @@ class Receiver(RadioDevice):
                  position,
                  orientation=(0.,0.,0.),
                  look_at=None,
+                 color=(39, 173, 95),
                  trainable_position=False,
                  trainable_orientation=False,
                  dtype=tf.complex64):
@@ -61,6 +66,7 @@ class Receiver(RadioDevice):
                          position=position,
                          orientation=orientation,
                          look_at=look_at,
+                         color=color,
                          trainable_position=trainable_position,
                          trainable_orientation=trainable_orientation,
                          dtype=dtype)

--- a/sionna/rt/renderer.py
+++ b/sionna/rt/renderer.py
@@ -268,13 +268,17 @@ def results_to_mitsuba_scene(scene, paths, show_paths, show_devices,
         'type': 'scene',
     }
     sc, tx_positions, rx_positions, _ = scene_scale(scene)
+    transmitter_colors = [[val/255 for val in transmitter.color] for 
+                              transmitter in scene.transmitters.values()]
+    receiver_colors = [[val/255 for val in receiver.color] for 
+                           receiver in scene.receivers.values()]
 
-    # --- Radio devices, shown as spheres (blue: transmitter, green: receiver)
+    # --- Radio devices, shown as spheres (Default - blue: transmitter, green: receiver)
     if show_devices:
         radius = max(0.0025 * sc, 1)
-        for source, color in ((tx_positions, [0.160, 0.502, 0.725]),
-                              (rx_positions, [0.153, 0.682, 0.375])):
-            for k, p in source.items():
+        for source, color in ((tx_positions, transmitter_colors),
+                              (rx_positions, receiver_colors)):
+            for index, (k, p) in enumerate(source.items()):
                 key = 'rd-' + k
                 assert key not in objects
                 objects[key] = {
@@ -283,7 +287,7 @@ def results_to_mitsuba_scene(scene, paths, show_paths, show_devices,
                     'radius': radius,
                     'light': {
                         'type': 'area',
-                        'radiance': {'type': 'rgb', 'value': color},
+                        'radiance': {'type': 'rgb', 'value': color[index]},
                     },
                 }
 

--- a/sionna/rt/transmitter.py
+++ b/sionna/rt/transmitter.py
@@ -34,6 +34,10 @@ class Transmitter(RadioDevice):
         :class:`~sionna.rt.Receiver`, or :class:`~sionna.rt.Camera` to look at.
         If set to `None`, then ``orientation`` is used to orientate the device.
 
+    color : [3], integer
+        Defines the rgb ``color`` for the device shown in the previewer or renderer.
+        Default RGB value for the transmitter is (40, 128, 184).
+
     trainable_position : bool
         Determines if the ``position`` is a trainable variable or not.
         Defaults to `False`.
@@ -52,6 +56,7 @@ class Transmitter(RadioDevice):
                  position,
                  orientation=(0.,0.,0.),
                  look_at=None,
+                 color=(40, 128, 184),
                  trainable_position=False,
                  trainable_orientation=False,
                  dtype=tf.complex64):
@@ -61,6 +66,7 @@ class Transmitter(RadioDevice):
                          position=position,
                          orientation=orientation,
                          look_at=look_at,
+                         color=color,
                          trainable_position=trainable_position,
                          trainable_orientation=trainable_orientation,
                          dtype=dtype)

--- a/test/unit/rt/test_radio_device.py
+++ b/test/unit/rt/test_radio_device.py
@@ -128,3 +128,25 @@ class TestRadioDevice(unittest.TestCase):
                 a = tf.squeeze(paths.a)
                 a_db = 20*np.log10(np.abs(a.numpy()))
                 self.assertTrue(np.abs(a_db-a_theo_db)< 1e-4)
+                
+    def test_default_coloring(self):
+        """Test default coloring of radio devices"""
+        scene = load_scene()
+        tx = Transmitter("tx", [1,2,-3], [0, 0, 0])
+        rx = Receiver("rx", [0,0,0], [0, 0, 0])
+        scene.add(tx)
+        scene.add(rx)
+
+        self.assertTrue(list(scene.transmitters.values())[0].color==(40, 128, 184))
+        self.assertTrue(list(scene.receivers.values())[0].color==(39, 173, 95))
+
+    def test_custom_coloring(self):
+        """Test custom coloring of radio devices"""
+        scene = load_scene()
+        tx = Transmitter("tx", [1,2,-3], [0, 0, 0], color=(204, 0, 0))
+        rx = Receiver("rx", [0,0,0], [0, 0, 0], color=(255, 255, 0))
+        scene.add(tx)
+        scene.add(rx)
+        
+        self.assertTrue(list(scene.transmitters.values())[0].color==(204, 0, 0))
+        self.assertTrue(list(scene.receivers.values())[0].color==(255, 255, 0))


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

This PR adds the color attribute to radio devices so that different colors are possible in the render or preview view despite green and blue (see screenshot below).

<img width="696" alt="Screenshot 2023-11-08 at 14 49 58" src="https://github.com/NVlabs/sionna/assets/7302097/4f94cc8d-f877-4719-a517-3081f45c5c23">


- Fixes a bug?

/

- Adds a new feature?

Documentation was added and also two basic unit tests.

- Introduces API changes?

/
- Other contributions

/


## Checklist

[X] Detailed description
[X] Added references to issues and discussions
[X] Added / modified documentation as needed
[X] Added / modified unit tests as needed
[X] Passes all tests
[X] Lint the code
[ ] Performed a self review
[X] Ensure you Signed-off the commits. Required to accept contributions!
[ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
