### PR TITLE
fix(docs): correct heading level

### DIFF
--- a/examples/Sionna_Ray_Tracing_Diffraction.ipynb
+++ b/examples/Sionna_Ray_Tracing_Diffraction.ipynb
@@ -98,13 +98,13 @@
    "id": "318a9c54-4bd1-4bb5-b615-6ab2d8143b21",
    "metadata": {},
    "source": [
-    "# Wedge vs Edge\n",
+    "## Wedge vs Edge\n",
     "\n",
     "First, it is important to know the difference between a *wedge* and an *edge*, and why we distinguish between them.\n",
     "\n",
     "Sionna defines a *wedge* as the line segment between two primitives, i.e., the common segment of two triangles. For example, a cubic building would have 12 wedges.\n",
     "\n",
-    "For primitives that have one or more line segments that are not shared with another primitive, Sionna refers to such line segments as *edges*. See [`sionna.rt.scene.floor_wall`](https://nvlabs.github.io/sionna/api/rt.html#sionna.rt.scene.floor_wall) for an example scene.\n",
+    "For primitives that have one or more line segments that are not shared with another primitive, Sionna refers to such line segments as *edges*. See [sionna.rt.scene.floor_wall](https://nvlabs.github.io/sionna/api/rt.html#sionna.rt.scene.floor_wall) for an example scene.\n",
     "\n",
     "By default, Sionna does not simulate diffraction on edges (`edge_diffraction=False`), to avoid problems such as diffraction on the exterior edges of the ground surface (modelled as a rectangular plane)."
    ]


### PR DESCRIPTION
Seems like my PR #214 introduced a problem where the heading level is not correct, which renders wrongly when docs are compiled.

![image](https://github.com/NVlabs/sionna/assets/27275099/a473c03e-bcb1-4d47-828f-c6ed01646c33)

> Note: I also fixed the link to API object, since `nbsphinx` does not seem to render nicely if surrounded code quotes.

Signed-off-by: Jérome Eertmans
<jeertmans@icloud.com>
