### PR TITLE
Add option of mitsuba parallel loading.

### DIFF
--- a/sionna/rt/scene.py
+++ b/sionna/rt/scene.py
@@ -105,7 +105,7 @@ class Scene:
 
         return cls._instance
 
-    def __init__(self, env_filename = None, dtype = tf.complex64):
+    def __init__(self, env_filename = None, dtype = tf.complex64, parallel=False):
 
         # If a filename is provided, loads the scene from it.
         # The previous scene is overwritten.
@@ -133,9 +133,9 @@ class Scene:
                 self._scene = mi.load_dict({"type": "scene",
                                             "integrator": {
                                                 "type": "path",
-                                            }})
+                                            }}, parallel=parallel)
             else:
-                self._scene = mi.load_file(env_filename)
+                self._scene = mi.load_file(env_filename, parallel=parallel)
 
             # Instantiate the solver
             self._solver_paths = SolverPaths(self, dtype=dtype)
@@ -1771,7 +1771,7 @@ class Scene:
         return used
 
 
-def load_scene(filename=None, dtype=tf.complex64):
+def load_scene(filename=None, dtype=tf.complex64, parallel=False):
     # pylint: disable=line-too-long
     r"""
     Load a scene from file
@@ -1797,7 +1797,7 @@ def load_scene(filename=None, dtype=tf.complex64):
     # Create empty scene using the reserved filename "__empty__"
     if filename is None:
         filename = "__empty__"
-    return Scene(filename, dtype=dtype)
+    return Scene(filename, dtype=dtype, parallel=parallel)
 
 #
 # Module variables for example scene files


### PR DESCRIPTION
Fix strange assertion error caused by mitsuba when load_scene is called many times because of this unresolved issue: https://github.com/mitsuba-renderer/mitsuba3/issues/849

<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

This PR added a new option to turn off the parallel loading in mitsuba.

- Fixes a bug?

This PR will mitigate the problem caused by mitsuba issue (https://github.com/mitsuba-renderer/mitsuba3/issues/849) when the scene is repeatedly loaded for many times.

- Adds a new feature?

This PR added a new feature to turn on/off the parallel loading scene behavior.

- Introduces API changes?

This is needed because loading scene in parallel is a behavior that has to be tuned on some machines.

- Other contributions

This submission is to add an option to switch a loading behavior that is previously hidden .


## Checklist

[x] Detailed description
[x] Added references to issues and discussions
[ ] Added / modified documentation as needed
[ ] Added / modified unit tests as needed
[ ] Passes all tests
[x] Lint the code
[x] Performed a self review
[x] Ensure you Signed-off the commits. Required to accept contributions!
[ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
