### PR TITLE
modify sim_ber callback to include all results

### DIFF
--- a/sionna/utils/misc.py
+++ b/sionna/utils/misc.py
@@ -498,20 +498,23 @@ def sim_ber(mc_fun,
         If `False`, the simulation ends and returns the intermediate simulation
         results.
 
-    callback: callable
-        Defaults to `None`. If specified, ``callback``
+    callback: callable Defaults to `None`. If specified, ``callback``
         will be called after each Monte-Carlo step. Can be used for
-        logging or advanced early stopping.
-        Input signature of ``callback`` must match `callback(mc_iter,
-        ebno_dbs, bit_errors, block_errors, nb_bits, nb_blocks)` where
-        ``mc_iter`` denotes the number of processed batches for the current
-        SNR, ``ebno_dbs`` is the current SNR point, ``bit_errors`` the number
-        of bit errors, ``block_errors`` the number of block errors, ``nb_bits``
-        the number of simulated bits, ``nb_blocks`` the number of simulated
-        blocks. If ``callable`` returns `sim_ber.CALLBACK_NEXT_SNR`, early
-        stopping is detected and the simulation will continue with the next SNR
-        point. If ``callable`` returns `sim_ber.CALLBACK_STOP`, the simulation
-        is stopped immediately. For `sim_ber.CALLBACK_CONTINUE` continues with
+        logging or advanced early stopping.  Input signature of
+        ``callback`` must match `callback(mc_iter, esno_idx, ebno_dbs,
+        bit_errors, block_errors, nb_bits, nb_blocks)` where
+        ``mc_iter`` denotes the number of processed batches for the
+        current SNR, ``esno_idx`` is the index of the current esno
+        step, ``ebno_dbs`` is the vector of all SNR points,
+        ``bit_errors`` the vector of number of bit errors for each
+        esno step, ``block_errors`` the vector of number of block
+        errors, ``nb_bits`` the vector of number of simulated bits,
+        ``nb_blocks`` the vector of number of simulated blocks. If
+        ``callable`` returns `sim_ber.CALLBACK_NEXT_SNR`, early
+        stopping is detected and the simulation will continue with the
+        next SNR point. If ``callable`` returns
+        `sim_ber.CALLBACK_STOP`, the simulation is stopped
+        immediately. For `sim_ber.CALLBACK_CONTINUE` continues with
         the simulation.
 
     dtype: tf.complex64
@@ -776,7 +779,7 @@ def sim_ber(mc_fun,
 
                 cb_state = sim_ber.CALLBACK_CONTINUE
                 if callback is not None:
-                    cb_state = callback (ii, ebno_dbs, bit_errors,
+                    cb_state = callback (ii, i, ebno_dbs, bit_errors,
                                        block_errors, nb_bits,
                                        nb_blocks)
                     if cb_state in (sim_ber.CALLBACK_STOP,

--- a/sionna/utils/misc.py
+++ b/sionna/utils/misc.py
@@ -498,19 +498,18 @@ def sim_ber(mc_fun,
         If `False`, the simulation ends and returns the intermediate simulation
         results.
 
-    callback: callable Defaults to `None`. If specified, ``callback``
-        will be called after each Monte-Carlo step. Can be used for
-        logging or advanced early stopping.  Input signature of
-        ``callback`` must match `callback(mc_iter, esno_idx, ebno_dbs,
-        bit_errors, block_errors, nb_bits, nb_blocks)` where
-        ``mc_iter`` denotes the number of processed batches for the
-        current SNR, ``esno_idx`` is the index of the current esno
-        step, ``ebno_dbs`` is the vector of all SNR points,
-        ``bit_errors`` the vector of number of bit errors for each
-        esno step, ``block_errors`` the vector of number of block
-        errors, ``nb_bits`` the vector of number of simulated bits,
-        ``nb_blocks`` the vector of number of simulated blocks. If
-        ``callable`` returns `sim_ber.CALLBACK_NEXT_SNR`, early
+    callback: `None` (default) | callable
+        If specified, ``callback`` will be called after each Monte-Carlo step.
+        Can be used for logging or advanced early stopping. Input signature of
+        ``callback`` must match `callback(mc_iter, snr_idx, ebno_dbs,
+        bit_errors, block_errors, nb_bits, nb_blocks)` where ``mc_iter``
+        denotes the number of processed batches for the current SNR point,
+        ``snr_idx`` is the index of the current SNR point, ``ebno_dbs`` is the
+        vector of all SNR points to be evaluated, ``bit_errors`` the vector of
+        number of bit errors for each SNR point, ``block_errors`` the vector of
+        number of block errors, ``nb_bits`` the vector of number of simulated
+        bits, ``nb_blocks`` the vector of number of simulated blocks,
+        respectively. If ``callable`` returns `sim_ber.CALLBACK_NEXT_SNR`, early
         stopping is detected and the simulation will continue with the
         next SNR point. If ``callable`` returns
         `sim_ber.CALLBACK_STOP`, the simulation is stopped

--- a/sionna/utils/misc.py
+++ b/sionna/utils/misc.py
@@ -776,9 +776,9 @@ def sim_ber(mc_fun,
 
                 cb_state = sim_ber.CALLBACK_CONTINUE
                 if callback is not None:
-                    cb_state = callback (ii, ebno_dbs[i], bit_errors[i],
-                                       block_errors[i], nb_bits[i],
-                                       nb_blocks[i])
+                    cb_state = callback (ii, ebno_dbs, bit_errors,
+                                       block_errors, nb_bits,
+                                       nb_blocks)
                     if cb_state in (sim_ber.CALLBACK_STOP,
                                     sim_ber.CALLBACK_NEXT_SNR):
                         # stop runtime timer


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Pass all stats to sim_ber callback so they can be used to log results for all es/no points

- Fixes a bug?

Describe what was wrong, and explain the solution in detail.

- Adds a new feature?

Describe the new feature, ensure that it is properly documented. Note that for new features unit tests are required.

- Introduces API changes?

Address in detail why it is needed. Explain and describe the consequences, does it break older code? Note that API changes might be delayed until a major bump release for inclusion.

- Other contributions

Please detail the nature of the submission.


## Checklist

[ ] Detailed description
[ ] Added references to issues and discussions
[ ] Added / modified documentation as needed
[ ] Added / modified unit tests as needed
[ ] Passes all tests
[ ] Lint the code
[ ] Performed a self review
[ ] Ensure you Signed-off the commits. Required to accept contributions!
[ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
