### PR TITLE
mapping: allow demapping infinite/high SNR symbols

### DIFF
--- a/sionna/mapping.py
+++ b/sionna/mapping.py
@@ -980,6 +980,8 @@ class Demapper(Layer):
                                               dtype.real_dtype,
                                               **kwargs)
 
+        self._no_threshold = tf.cast(np.finfo(dtype.as_numpy_dtype).tiny, dtype.real_dtype)
+
     @property
     def constellation(self):
         return self._constellation
@@ -1001,6 +1003,8 @@ class Demapper(Layer):
         # Add a dummy dimension for broadcasting. This is not needed when no
         # is a scalar, but also does not do any harm.
         no = tf.expand_dims(no, axis=-1)
+        # Deal with zero or very small values.
+        no = tf.math.maximum(no, self._no_threshold)
 
         # Compute exponents
         exponents = -squared_dist/no


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Closes issue #326.
This simply adds the machine epsilon to `no` before computing the exponents. A min threshold could be used instead, but with this method differentiability is preserved. I don't think it makes sense for `_eps` to be user-configurable.
Given that there is a max LLR value enforced at the soft decoder side, I believe this should be enough to prevent other overflow issues.

I could add a test for this if needed (e.g.: https://gist.github.com/japm48/41bc963efec39e506c17e419c3d1e13f).

- Introduces API changes?

No.


## Checklist

- [x] Detailed description
- [ ] Added references to issues and discussions
- [ ] Added / modified documentation as needed
- [ ] Added / modified unit tests as needed
- [ ] Passes all tests
- [ ] Lint the code
- [ ] Performed a self review
- [x] Ensure you Signed-off the commits. Required to accept contributions!
- [ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
