### PR TITLE
Fix data type issue in _compute_doppler_shifts, fixes #426

### DIFF
--- a/sionna/rt/solver_paths.py
+++ b/sionna/rt/solver_paths.py
@@ -4124,7 +4124,7 @@ class SolverPaths(SolverBase):
         # Compute Doppler shift per path
         #[num_targets, num_sources, max_num_paths]
         doppler = tf.reduce_sum(velocity*k_diff, axis=-1)
-        doppler = tf.where(objects_mask, 0, doppler)
+        doppler = tf.where(objects_mask, tf.constant(0, doppler.dtype), doppler)
         doppler = tf.reduce_sum(doppler, axis=0)
         doppler /= self._scene.wavelength
         return doppler


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Very minor one-line fix for issue #426.
The line in the source code used to say
```py
tf.where(objects_mask, 0, doppler)
```
which causes a TypeError (`TypeError: Input 'e' of 'SelectV2' Op has type float32 that does not match type int32 of argument 't'.`), because `0` is an int32, whereas `doppler` is a float32 and `tf.where` wants to have same dtypes (at least when using `@tf.function` with my TensorFlow installation).
I changed it so that the dtype of `0` is chosen based on the dtype of `doppler`:
```py
doppler = tf.where(objects_mask, tf.constant(0, doppler.dtype), doppler)
```

Not sure if this is the correct way to fix it, but the bug certainly disappears for me.

## Checklist

- [x] Detailed description
- [x] Added references to issues and discussions
- [ ] Added / modified documentation as needed
- [ ] Added / modified unit tests as needed
- [ ] Passes all tests
- [ ] Lint the code
- [ ] Performed a self review
- [x] Ensure you Signed-off the commits. Required to accept contributions!
- [ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
