### PR TITLE
Fix cyclic prefix length of first symbol for 5g NR PUSCH

### DIFF
--- a/sionna/nr/pusch_transmitter.py
+++ b/sionna/nr/pusch_transmitter.py
@@ -168,7 +168,9 @@ class PUSCHTransmitter(Layer):
                             subcarrier_spacing=self._subcarrier_spacing,
                             num_tx=self._num_tx,
                             num_streams_per_tx=self._num_layers,
-                            cyclic_prefix_length=self._cyclic_prefix_length,
+                            # TODO: pass vector of cyclic prefix lengths
+                            # (requires rewrite of channel simulation code)
+                            cyclic_prefix_length=self._cyclic_prefix_length[1],
                             pilot_pattern=self._pilot_pattern,
                             dtype=dtype)
 

--- a/test/unit/nr/test_pusch_config.py
+++ b/test/unit/nr/test_pusch_config.py
@@ -8,7 +8,7 @@ import unittest
 import numpy as np
 import tensorflow as tf
 import sionna
-from sionna.nr import PUSCHConfig
+from sionna.nr import PUSCHConfig, CarrierConfig
 from sionna import config
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
@@ -228,3 +228,44 @@ class TestPUSCHDMRS(unittest.TestCase):
         for i in range(5):
             pusch_config.tpmi = i
             self.assertTrue(np.allclose(pusch_config.dmrs_grid_precoded/np.sqrt(3), ref[i]))
+
+
+class TestCarrierConfig(unittest.TestCase):
+    """Tests for the CarrierConfig Class"""
+
+    def test_cyclic_prefix_length(self):
+        carrier_config = CarrierConfig(subcarrier_spacing=15, slot_number=0)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, ([5.2] + [4.69]*6)*2, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=15, slot_number=1)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, ([5.2] + [4.69]*6)*2, decimal=2)
+
+        carrier_config = CarrierConfig(subcarrier_spacing=30, slot_number=0)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [2.86] + [2.34]*13, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=30, slot_number=1)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [2.86] + [2.34]*13, decimal=2)
+
+        carrier_config = CarrierConfig(subcarrier_spacing=60, slot_number=0)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [1.69] + [1.17]*13, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=60, slot_number=1)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [1.17] * 14, decimal=2)
+
+        carrier_config = CarrierConfig(subcarrier_spacing=60, slot_number=0, cyclic_prefix='extended')
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [4.17] * 12, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=60, slot_number=1, cyclic_prefix='extended')
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [4.17] * 12, decimal=2)
+
+        carrier_config = CarrierConfig(subcarrier_spacing=120, slot_number=0)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [1.11] + [0.59] * 13, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=120, slot_number=1)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [0.59] * 14, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=120, slot_number=2)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [0.59] * 14, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=120, slot_number=3)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [0.59] * 14, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=120, slot_number=4)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [1.11] + [0.59] * 13, decimal=2)
+
+        carrier_config = CarrierConfig(subcarrier_spacing=240, slot_number=0)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [0.81] + [0.29] * 13, decimal=2)
+        carrier_config = CarrierConfig(subcarrier_spacing=240, slot_number=1)
+        np.testing.assert_array_almost_equal(carrier_config.cyclic_prefix_length * 1e6, [0.29] * 14, decimal=2)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

According to [TS 138.211](https://www.etsi.org/deliver/etsi_ts/138200_138299/138211/15.03.00_60/ts_138211v150300p.pdf), section 5.3.1, the length of the cyclic prefix is extended by 16κ for the first symbol of each half subframe.

An attempt to implement this was done in [CarrierConfig.cyclic_prefix_length](https://github.com/NVlabs/sionna/blob/8ad32bc6eca75cfe4003a6a5f035cf4a435ff84e/sionna/nr/carrier_config.py#L254), but the code checks for the slot number instead of the symbol number.

See also #425.

- Fixes a bug?

In order to support a different cyclic prefix lengths for the first symbol of each "block" (a half subframe in 5G NR and a slot in LTE), the parameters `cyclic_prefix_length_first_symbol` and `symbols_per_block` were added to `OFDMModulator`/`OFDMDemodulator`. The algorithm of `OFDMModulator`/`OFDMDemodulator` was modified to reshape the data into blocks (while adding zero padding beforehand if the number of OFDM symbols is not an integer multiple of `symbols_per_block`). Then the additional cyclic prefix is added/removed from the beginning of each block. Afterwards the data is reshaped into the proper shape and the zero padding is removed (if necessary).

The property `cyclic_prefix_length_first_symbol` was added to `CarrierConfig` and `PUSCHTransmitter`/`PUSCHReceiver` were modified to pass this parameter to `OFDMModulator`/`OFDMDemodulator`.

- Adds a new feature?

No

- Introduces API changes?

Optional parameters have been added to `OFDMModulator`/`OFDMDemodulator`. `CarrierConfig` got a new property `cyclic_prefix_length_first_symbol` and the return value of `cyclic_prefix_length` might change.

5G PUSCH data sets generated with the old version can't be loaded with the new version. Unfortunately, I don't see a way to fix this bug while being backwards compatible.

- Other contributions

Fixed some spelling errors.


## Checklist

- [x] Detailed description
- [x] Added references to issues and discussions
- [x] Added / modified documentation as needed
- [x] Added / modified unit tests as needed
- [x] Passes all tests
- [x] Lint the code
- [x] Performed a self review
- [x] Ensure you Signed-off the commits. Required to accept contributions!
