### PR TITLE
fix(docs): broken link to LLVM backend installation

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -11,7 +11,7 @@ Although not necessary, we recommend running Sionna in a `Docker container <http
     We recommend Ubuntu 22.04.
     Earlier versions of TensorFlow may still work but are not recommended because of known, unpatched CVEs.
 
-    To run the ray tracer on CPU, `LLVM <https://llvm.org>`_ is required by DrJit. Please check the `installation instructions for the LLVM backend <https://drjit.readthedocs.io/en/latest/firststeps-py.html#llvm-backend>`_.
+    To run the ray tracer on CPU, `LLVM <https://llvm.org>`_ is required by DrJit. Please check the `installation instructions for the LLVM backend <https://drjit.readthedocs.io/en/stable/firststeps-py.html#llvm-backend>`_.
     The ray tracing preview requires a recent version of `JupyterLab`. You can upgrade to the latest version via ``pip install --upgrade ipykernel jupyterlab`` (requires restart of `JupyterLab`).
 
     We refer to the `TensorFlow GPU support tutorial <https://www.tensorflow.org/install/gpu>`_ for GPU support and the required driver setup.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

Hello, I just noticed that the link to the LLVM backend installation instruction was broken.

Indeed, Dr.Jit's documentation is completely different on the `latest` branch, and the documentation about LLVM backend will be on this page: https://drjit.readthedocs.io/en/latest/what.html#backends.

I am not sure whether it is best to update now to `stable`, and later update the link when the version 1.0.0 of Dr.Jit will be release, or directly use the new link (https://drjit.readthedocs.io/en/latest/what.html#backends), and hope it won't change :-)

## Checklist

- [x] Detailed description
- ~~[ ] Added references to issues and discussions~~
- [x] Added / modified documentation as needed
- ~~[ ] Added / modified unit tests as needed~~
- ~~[ ] Passes all tests~~
- ~~[ ] Lint the code~~
- [x] Performed a self review
- [x] Ensure you Signed-off the commits. Required to accept contributions!
- ~~[ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.~~
