### PR TITLE
Bug in `prior shape` for symbol outputs with MMSE-PIC Detector for `OFDM_MIMO_Detection.ipynb`

### DIFF
--- a/examples/OFDM_MIMO_Detection.ipynb
+++ b/examples/OFDM_MIMO_Detection.ipynb
@@ -1037,7 +1037,7 @@
     "            if self._output == \"bit\":\n",
     "                prior_shape = bits_shape\n",
     "            elif self._output == \"symbol\":\n",
-    "                prior_shape = tf.concat([tf.shape(x), [self.num_bits_per_symbol]], axis=0)\n",
+    "                prior_shape = tf.concat([tf.shape(x), [2**self.num_bits_per_symbol]], axis=0) # Use num constellation points, not num bits per symbol\n",
     "            prior = tf.zeros(prior_shape)\n",
     "            det_out = self.detector((y_rg,h_hat,prior,err_var,no))\n",
     "        else:\n",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: Copyright (c) 2021-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
SPDX-License-Identifier: Apache-2.0
-->

## Description

One-Line Bugfix Summary: For the MMSE-PIC detector in the `MIMOOFDMLink` class, num constellation points should be used (not num bits per symbol) when creating the prior shape when the output is set to "symbol".

Currently, the prior's shape is created as `prior_shape = tf.concat([tf.shape(x), [self.num_bits_per_symbol]], axis=0)`. Notice that the last dimension added is the number of bits per symbol.

However, the API documentation notes for the [`MMSEPICDetector class`](https://nvlabs.github.io/sionna/api/ofdm.html#mmsepicdetector) indicate that the `prior` input should follow: 

"prior ([batch_size, num_tx, num_streams, num_data_symbols x num_bits_per_symbol] or [batch_size, num_tx, num_streams, num_data_symbols, num_points], tf.float) – Prior of the transmitted signals. If output equals “bit”, LLRs of the transmitted bits are expected. If output equals “symbol”, logits of the transmitted constellation points are expected." 

Thus, the code should be changed to `prior_shape = tf.concat([tf.shape(x), [2**self.num_bits_per_symbol]], axis=0)`. Now, the last dimension correctly matches `num_points`. For QAM, this is equal to `2**num_bits_per_symbol`. 

It should be noted that without this change, the `OFDM_MIMO_Detection.ipynb` example fails to run in Google Colab. With the correction, all plots are fully generated and match the documented tutorial.

## Checklist

- [x] Detailed description
- [x] Added references to issues and discussions
~~- [ ] Added / modified documentation as needed~~
~~- [ ] Added / modified unit tests as needed~~
- [x] Passes all tests
- [ ] Lint the code
- [x] Performed a self review
- [x] Ensure you Signed-off the commits. Required to accept contributions!
- [ ] Co-authored with someone? Add Co-authored-by: user@domain and ensure they signed off their commits too.
