### PR TITLE
fix(indoor): sample d_2D-in as min(U1,U2) per TR 38.901 §7.4.3.1

### DIFF
--- a/src/sionna/phy/channel/tr38901/system_level_scenario.py
+++ b/src/sionna/phy/channel/tr38901/system_level_scenario.py
@@ -1099,8 +1099,11 @@ class SystemLevelScenario(Object):
             torch.tensor(0.0, dtype=self.dtype, device=self.device),
         )
 
-        # Sample the indoor 2D distances for each BS-UT link
-        distance_2d_in = (
+        # Sample the indoor 2D distances for each BS-UT link.
+        # Per TR 38.901 §7.4.3.1, d_2D-in = min(U1, U2) where U1 and U2
+        # are independent uniform samples over [min_2d_in, max_2d_in].
+        # A single uniform sample was used previously, which is incorrect.
+        u1 = (
             rand(
                 (self.batch_size, self.num_bs, self.num_ut),
                 dtype=self.dtype,
@@ -1109,7 +1112,18 @@ class SystemLevelScenario(Object):
             )
             * (self.max_2d_in - self.min_2d_in)
             + self.min_2d_in
-        ) * indoor_mask
+        )
+        u2 = (
+            rand(
+                (self.batch_size, self.num_bs, self.num_ut),
+                dtype=self.dtype,
+                device=self.device,
+                generator=self.torch_rng,
+            )
+            * (self.max_2d_in - self.min_2d_in)
+            + self.min_2d_in
+        )
+        distance_2d_in = torch.minimum(u1, u2) * indoor_mask
         self._update_attr("_distance_2d_in", distance_2d_in)
 
         # Compute the outdoor 2D distances

--- a/test/unit/channel/test_3gpp_channel_scenario.py
+++ b/test/unit/channel/test_3gpp_channel_scenario.py
@@ -134,6 +134,86 @@ class TestRMaScenario:
         max_err = torch.max(torch.abs(d_2d - d_2d_in - d_2d_out) / d_2d)
         assert max_err <= MAX_ERR
 
+    def test_d2d_in_range_and_outdoor_zero(self, device, precision):
+        """Test that d_2D-in is within [0, max_2d_in] for indoor UTs and
+        exactly 0 for outdoor UTs, per TR 38.901 §7.4.3.1."""
+        ut_array, bs_array = create_arrays(CARRIER_FREQUENCY, device, precision)
+        scenario = RMaScenario(
+            carrier_frequency=CARRIER_FREQUENCY,
+            ut_array=ut_array,
+            bs_array=bs_array,
+            direction="uplink",
+            precision=precision,
+            device=device,
+        )
+        dtype = torch.float32 if precision == "single" else torch.float64
+
+        ut_loc = generate_random_loc(
+            BATCH_SIZE, NB_UT, (100, 2000), (100, 2000), (H_UT, H_UT),
+            dtype=dtype, device=device
+        )
+        bs_loc = generate_random_loc(
+            BATCH_SIZE, NB_BS, (0, 100), (0, 100), (H_BS, H_BS),
+            dtype=dtype, device=device
+        )
+        ut_orientations = torch.zeros(BATCH_SIZE, NB_UT, 3, dtype=dtype, device=device)
+        bs_orientations = torch.zeros(BATCH_SIZE, NB_BS, 3, dtype=dtype, device=device)
+        ut_velocities   = torch.zeros(BATCH_SIZE, NB_UT, 3, dtype=dtype, device=device)
+
+        # Force all UTs indoors so we get meaningful d_2d_in samples
+        in_state = torch.ones(BATCH_SIZE, NB_UT, dtype=torch.bool, device=device)
+
+        scenario.set_topology(
+            ut_loc, bs_loc, ut_orientations, bs_orientations, ut_velocities, in_state
+        )
+
+        d_2d_in = scenario.distance_2d_in
+        max_2d_in = scenario.max_2d_in.item()
+
+        # All indoor UTs must have d_2d_in in [0, max_2d_in]
+        assert torch.all(d_2d_in >= torch.tensor(0.0, dtype=dtype, device=device)), \
+            "d_2D-in must be >= 0 for all indoor UTs"
+        assert torch.all(d_2d_in <= torch.tensor(max_2d_in, dtype=dtype, device=device)), \
+            f"d_2D-in must be <= max_2d_in ({max_2d_in}m) for all indoor UTs"
+
+    def test_d2d_in_outdoor_uts_are_zero(self, device, precision):
+        """Test that d_2D-in is exactly 0 for all outdoor UTs."""
+        ut_array, bs_array = create_arrays(CARRIER_FREQUENCY, device, precision)
+        scenario = RMaScenario(
+            carrier_frequency=CARRIER_FREQUENCY,
+            ut_array=ut_array,
+            bs_array=bs_array,
+            direction="uplink",
+            precision=precision,
+            device=device,
+        )
+        dtype = torch.float32 if precision == "single" else torch.float64
+
+        ut_loc = generate_random_loc(
+            BATCH_SIZE, NB_UT, (100, 2000), (100, 2000), (H_UT, H_UT),
+            dtype=dtype, device=device
+        )
+        bs_loc = generate_random_loc(
+            BATCH_SIZE, NB_BS, (0, 100), (0, 100), (H_BS, H_BS),
+            dtype=dtype, device=device
+        )
+        ut_orientations = torch.zeros(BATCH_SIZE, NB_UT, 3, dtype=dtype, device=device)
+        bs_orientations = torch.zeros(BATCH_SIZE, NB_BS, 3, dtype=dtype, device=device)
+        ut_velocities   = torch.zeros(BATCH_SIZE, NB_UT, 3, dtype=dtype, device=device)
+
+        # Force all UTs outdoors
+        in_state = torch.zeros(BATCH_SIZE, NB_UT, dtype=torch.bool, device=device)
+
+        scenario.set_topology(
+            ut_loc, bs_loc, ut_orientations, bs_orientations, ut_velocities, in_state
+        )
+
+        d_2d_in = scenario.distance_2d_in
+
+        # All outdoor UTs must have d_2d_in exactly 0
+        assert torch.all(d_2d_in == torch.tensor(0.0, dtype=dtype, device=device)), \
+            "d_2D-in must be exactly 0 for all outdoor UTs"
+
     def test_get_param(self, device, precision):
         """Test the get_param() function retrieves correct values"""
         ut_array, bs_array = create_arrays(CARRIER_FREQUENCY, device, precision)


### PR DESCRIPTION
## Summary

Fixes #1108

The indoor 2D distance `d_2D-in` in `_sample_indoor_distance()` was computed from a single uniform sample `U(min_2d_in, max_2d_in)`. Per TR 38.901 §7.4.3.1, it must be `min(d_2D-in-1, d_2D-in-2)` where both are independent uniform samples over the same range.

## Root Cause

The previous implementation produced a flat uniform distribution. The correct `min(U1, U2)` of two i.i.d. uniforms follows a distribution skewed toward the lower bound — meaning indoor UTs are statistically placed closer to the building wall, which materially affects pathloss and O2I penetration loss calculations.

## Fix

Draw two independent `rand()` samples and take `torch.minimum(u1, u2)` before applying `indoor_mask`:

```python
u1 = rand(...) * (self.max_2d_in - self.min_2d_in) + self.min_2d_in
u2 = rand(...) * (self.max_2d_in - self.min_2d_in) + self.min_2d_in
distance_2d_in = torch.minimum(u1, u2) * indoor_mask
```

The fix applies to all three subclasses (UMa, UMi, RMa) since `_sample_indoor_distance()` lives in the base class `SystemLevelScenario`.

## Changes

- `src/sionna/phy/channel/tr38901/system_level_scenario.py` — replace single uniform sample with `min(U1, U2)`
- `test/unit/channel/test_3gpp_channel_scenario.py` — two new tests added to `TestRMaScenario`:
  - `test_d2d_in_range_and_outdoor_zero` — verifies `d_2D-in` is within `[0, max_2d_in]` for all-indoor topology
  - `test_d2d_in_outdoor_uts_are_zero` — verifies `d_2D-in` is exactly `0` for all-outdoor topology

## Testing

New tests cover range bounds and the `indoor_mask` zeroing logic. The existing `test_distance_calculation` continues to verify additive consistency (`d_2D-in + d_2D-out == d_2D`).