### PR TITLE
fix(tutorial): correct x-axis label in CDL channel frequency response plot

### DIFF
--- a/tutorials/phy/MIMO_OFDM_Transmissions_over_CDL.ipynb
+++ b/tutorials/phy/MIMO_OFDM_Transmissions_over_CDL.ipynb
@@ -787,7 +787,7 @@
     "plt.title(\"Channel frequency response\")\n",
     "plt.plot(np.real(h_freq[0,0,0,0,0,0,:].cpu().numpy()))\n",
     "plt.plot(np.imag(h_freq[0,0,0,0,0,0,:].cpu().numpy()))\n",
-    "plt.xlabel(\"OFDM Symbol Index\")\n",
+    "plt.xlabel(\"Subcarrier Index\")\n",
     "plt.ylabel(r\"$h$\")\n",
     "plt.legend([\"Real part\", \"Imaginary part\"]);"
    ]


### PR DESCRIPTION
## Summary

In `tutorials/phy/MIMO_OFDM_Transmissions_over_CDL.ipynb`, the channel
frequency response plot uses the x-axis label `"OFDM Symbol Index"`.

The plotted data is:

```python
h_freq[0, 0, 0, 0, 0, 0, :]
```

`h_freq` has shape:

```
[batch_size, num_rx, num_rx_ant, num_tx, num_tx_ant, num_time_steps, fft_size]
```

Index 5 is fixed at `num_time_steps = 0`. Index 6 varies over `fft_size`,
which is the subcarrier (frequency) dimension. The x-axis therefore
represents subcarrier index, not OFDM symbol index.

## Root cause

Label was set to `"OFDM Symbol Index"` when the slice iterates the last
tensor axis (`fft_size`), which corresponds to frequency bins, not time
slots.

## Fix

Change the x-axis label to `"Subcarrier Index"` to match what the data
actually represents.

## Validation

- Confirmed tensor shape from `cir_to_ofdm_channel` output:
  `[batch, num_rx, num_rx_ant, num_tx, num_tx_ant, num_time_steps, fft_size]`
- Confirmed that index 5 (time step) is held at 0, index 6 (subcarrier)
  varies in the plot.
- One-line label change; no behavior change.

Fixes #1157

Signed-off-by: Aryan Putta <aryansputta@gmail.com>