### PR TITLE
fix(docs): remove spurious vertical scrollbar on display equations

### DIFF
--- a/doc/source/_static/custom.css
+++ b/doc/source/_static/custom.css
@@ -109,6 +109,15 @@ div.citation > p.cite-backrefs {
     margin-bottom: 0.3em !important;
 }
 
+/* MathJax v4 (Sphinx 9): the pydata theme sets `overflow: auto` on
+   `div.math mjx-container`, which adds a spurious vertical scrollbar to every
+   display equation. Match that selector to keep horizontal scroll for wide
+   equations while suppressing the vertical scrollbar. */
+div.math mjx-container {
+    overflow-x: auto;
+    overflow-y: hidden;
+}
+
 /* Rubric headings (Note, Example, Attributes, Methods, etc.): line below, consistent style */
 p.rubric {
     border-bottom: 1px solid var(--pst-color-border);


### PR DESCRIPTION
## Summary

Every display equation in the documentation renders with a small, spurious vertical scrollbar.

**Cause:** With the current Sphinx / MathJax v4 setup, `pydata-sphinx-theme` applies `overflow: auto` to `div.math mjx-container`. A sub-pixel height mismatch between the theme font and MathJax's font then triggers a vertical scrollbar on every equation.

**Fix:** Override the theme using the same selector. Set `overflow-y: hidden` to suppress vertical scrollbars and `overflow-x: auto` to preserve horizontal scrolling for wide equations.

## Changes

- `doc/source/_static/custom.css`: set `overflow-x: auto` and `overflow-y: hidden` for display-equation MathJax containers.

## Testing

Rebuilt the documentation and verified that display equations on the EM primer page no longer show vertical scrollbars, while wide equations remain horizontally scrollable.
