### PR TITLE
Fix device migration for Sionna PHY module state

### DIFF
--- a/src/sionna/phy/channel/optical/edfa.py
+++ b/src/sionna/phy/channel/optical/edfa.py
@@ -129,14 +129,17 @@ class EDFA(Block):
         else:
             self.register_buffer("_n_sp", self._f / 2.0 * self._g / (self._g - 1.0))
 
-        self._rho_n_ase = (
-            self._n_sp * (self._g - 1.0) * H * self._f_c
+        self.register_buffer(
+            "_rho_n_ase",
+            self._n_sp * (self._g - 1.0) * H * self._f_c,
+            persistent=False,
         )  # Noise density in (W/Hz)
 
-        self._p_n_ase = 2.0 * self._rho_n_ase / self._dt  # Noise power in (W)
+        p_n_ase = 2.0 * self._rho_n_ase / self._dt  # Noise power in (W)
 
         if self._with_dual_polarization:
-            self._p_n_ase = self._p_n_ase / 2.0
+            p_n_ase = p_n_ase / 2.0
+        self.register_buffer("_p_n_ase", p_n_ase, persistent=False)
 
     def call(self, inputs: torch.Tensor) -> torch.Tensor:
         """Process the optical input signal through the EDFA.

--- a/src/sionna/phy/channel/optical/fiber.py
+++ b/src/sionna/phy/channel/optical/fiber.py
@@ -202,7 +202,11 @@ class SSFM(Block):
 
         # Only used for constant step width
         if not self._adaptive:
-            self._dz = self._length / self._n_ssfm
+            self.register_buffer(
+                "_dz",
+                self._length / self._n_ssfm,
+                persistent=False,
+            )
 
         # Register as buffers for CUDAGraph compatibility
         self.register_buffer("_n_sp", torch.tensor(n_sp, dtype=self.dtype, device=self.device))
@@ -218,12 +222,17 @@ class SSFM(Block):
         self._with_manakov = with_manakov
         self._with_nonlinearity = with_nonlinearity
 
-        self._rho_n = H * self._f_c * self._alpha * self._length * self._n_sp  # (W/Hz)
+        self.register_buffer(
+            "_rho_n",
+            H * self._f_c * self._alpha * self._length * self._n_sp,
+            persistent=False,
+        )  # (W/Hz)
 
         # Calculate noise power depending on simulation bandwidth
-        self._p_n_ase = self._rho_n / self._sample_duration / self._t_norm  # (Ws)
+        p_n_ase = self._rho_n / self._sample_duration / self._t_norm  # (Ws)
         if self._with_manakov:
-            self._p_n_ase = self._p_n_ase / 2.0
+            p_n_ase = p_n_ase / 2.0
+        self.register_buffer("_p_n_ase", p_n_ase, persistent=False)
 
         # Pre-compute Hamming window
         if self._half_window_length > 0:

--- a/src/sionna/phy/channel/tr38901/cdl.py
+++ b/src/sionna/phy/channel/tr38901/cdl.py
@@ -273,24 +273,24 @@ class CDL(ChannelModel):
         self._allocated_num_time_steps: int = 0
 
         # Velocity buffers
-        self.register_buffer("_velocity_r", None)
-        self.register_buffer("_velocity_phi", None)
-        self.register_buffer("_velocity_theta", None)
-        self.register_buffer("_velocity_buffer", None)
+        self.register_buffer("_velocity_r", None, persistent=False)
+        self.register_buffer("_velocity_phi", None, persistent=False)
+        self.register_buffer("_velocity_theta", None, persistent=False)
+        self.register_buffer("_velocity_buffer", None, persistent=False)
 
         # Topology buffers (for non-LoS case)
-        self.register_buffer("_los_aoa_zeros", None)
-        self.register_buffer("_los_aod_zeros", None)
-        self.register_buffer("_los_zoa_zeros", None)
-        self.register_buffer("_los_zod_zeros", None)
-        self.register_buffer("_los_indicator", None)
-        self.register_buffer("_distance_3d_zeros", None)
+        self.register_buffer("_los_aoa_zeros", None, persistent=False)
+        self.register_buffer("_los_aod_zeros", None, persistent=False)
+        self.register_buffer("_los_zoa_zeros", None, persistent=False)
+        self.register_buffer("_los_zod_zeros", None, persistent=False)
+        self.register_buffer("_los_indicator", None, persistent=False)
+        self.register_buffer("_distance_3d_zeros", None, persistent=False)
 
         # Shuffle buffers
-        self.register_buffer("_shuffle_random_aoa", None)
-        self.register_buffer("_shuffle_random_aod", None)
-        self.register_buffer("_shuffle_random_zoa", None)
-        self.register_buffer("_shuffle_random_zod", None)
+        self.register_buffer("_shuffle_random_aoa", None, persistent=False)
+        self.register_buffer("_shuffle_random_aod", None, persistent=False)
+        self.register_buffer("_shuffle_random_zoa", None, persistent=False)
+        self.register_buffer("_shuffle_random_zod", None, persistent=False)
 
     def allocate_for_batch_size(
         self, batch_size: int, num_time_steps: int = 100
@@ -312,43 +312,90 @@ class CDL(ChannelModel):
 
         # Velocity buffers (only needed if ut_velocity is None)
         if self._ut_velocity is None:
-            self.register_buffer("_velocity_r",
-                torch.zeros(batch_size, 1, dtype=self.dtype, device=self.device))
-            self.register_buffer("_velocity_phi",
-                torch.zeros(batch_size, 1, dtype=self.dtype, device=self.device))
-            self.register_buffer("_velocity_theta",
-                torch.zeros(batch_size, 1, dtype=self.dtype, device=self.device))
-            self.register_buffer("_velocity_buffer",
-                torch.zeros(batch_size, 3, dtype=self.dtype, device=self.device))
+            self.register_buffer(
+                "_velocity_r",
+                torch.zeros(batch_size, 1, dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_velocity_phi",
+                torch.zeros(batch_size, 1, dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_velocity_theta",
+                torch.zeros(batch_size, 1, dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_velocity_buffer",
+                torch.zeros(batch_size, 3, dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
 
         # Topology buffers (always needed for non-LoS case)
         if not self._has_los:
-            self.register_buffer("_los_aoa_zeros",
-                torch.zeros(1, 1, 1, dtype=self.dtype, device=self.device))
-            self.register_buffer("_los_aod_zeros",
-                torch.zeros(1, 1, 1, dtype=self.dtype, device=self.device))
-            self.register_buffer("_los_zoa_zeros",
-                torch.zeros(1, 1, 1, dtype=self.dtype, device=self.device))
-            self.register_buffer("_los_zod_zeros",
-                torch.zeros(1, 1, 1, dtype=self.dtype, device=self.device))
+            self.register_buffer(
+                "_los_aoa_zeros",
+                torch.zeros(1, 1, 1, dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_los_aod_zeros",
+                torch.zeros(1, 1, 1, dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_los_zoa_zeros",
+                torch.zeros(1, 1, 1, dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
+            self.register_buffer(
+                "_los_zod_zeros",
+                torch.zeros(1, 1, 1, dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
 
-        self.register_buffer("_los_indicator",
-            torch.full((batch_size, 1, 1), self._has_los, dtype=torch.bool, device=self.device))
-        self.register_buffer("_distance_3d_zeros",
-            torch.zeros((batch_size, 1, 1), dtype=self.dtype, device=self.device))
+        self.register_buffer(
+            "_los_indicator",
+            torch.full(
+                (batch_size, 1, 1),
+                self._has_los,
+                dtype=torch.bool,
+                device=self.device,
+            ),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_distance_3d_zeros",
+            torch.zeros((batch_size, 1, 1), dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
         # Shuffle buffers for random coupling
         num_clusters = self._num_clusters
         rays_per_cluster = self._rays_per_cluster
         shuffle_shape = (batch_size, 1, 1, num_clusters, rays_per_cluster)
-        self.register_buffer("_shuffle_random_aoa",
-            torch.zeros(shuffle_shape, dtype=self.dtype, device=self.device))
-        self.register_buffer("_shuffle_random_aod",
-            torch.zeros(shuffle_shape, dtype=self.dtype, device=self.device))
-        self.register_buffer("_shuffle_random_zoa",
-            torch.zeros(shuffle_shape, dtype=self.dtype, device=self.device))
-        self.register_buffer("_shuffle_random_zod",
-            torch.zeros(shuffle_shape, dtype=self.dtype, device=self.device))
+        self.register_buffer(
+            "_shuffle_random_aoa",
+            torch.zeros(shuffle_shape, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_shuffle_random_aod",
+            torch.zeros(shuffle_shape, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_shuffle_random_zoa",
+            torch.zeros(shuffle_shape, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_shuffle_random_zod",
+            torch.zeros(shuffle_shape, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
         # Allocate in the channel coefficients generator
         self._cir_gen.allocate_for_batch_size(
@@ -855,5 +902,3 @@ class CDL(ChannelModel):
             shuffled_zod = self._shuffle_angles(zod)
 
         return shuffled_aoa, shuffled_aod, shuffled_zoa, shuffled_zod
-
-

--- a/src/sionna/phy/channel/tr38901/channel_coefficients.py
+++ b/src/sionna/phy/channel/tr38901/channel_coefficients.py
@@ -169,8 +169,14 @@ class ChannelCoefficientsGenerator(Object):
         super().__init__(precision=precision, device=device)
 
         # Wavelength (m)
-        self._lambda_0 = torch.as_tensor(
-            SPEED_OF_LIGHT / carrier_frequency, dtype=self.dtype, device=self.device
+        self.register_buffer(
+            "_lambda_0",
+            torch.as_tensor(
+                SPEED_OF_LIGHT / carrier_frequency,
+                dtype=self.dtype,
+                device=self.device,
+            ),
+            persistent=False,
         )
         self._tx_array = tx_array
         self._rx_array = rx_array
@@ -231,14 +237,14 @@ class ChannelCoefficientsGenerator(Object):
         self._allocated_rays_per_cluster: int = 0
 
         # Sample times buffer
-        self.register_buffer("_sample_times", None)
+        self.register_buffer("_sample_times", None, persistent=False)
 
         # Step 10 buffer (random phases)
-        self.register_buffer("_phi_buffer", None)
+        self.register_buffer("_phi_buffer", None, persistent=False)
 
         # Intermediate buffers for step 11
-        self.register_buffer("_zeros_buffer_small", None)
-        self.register_buffer("_zeros_buffer_time", None)
+        self.register_buffer("_zeros_buffer_small", None, persistent=False)
+        self.register_buffer("_zeros_buffer_time", None, persistent=False)
 
     def allocate_for_batch_size(
         self,
@@ -266,18 +272,29 @@ class ChannelCoefficientsGenerator(Object):
         self._allocated_rays_per_cluster = rays_per_cluster
 
         # Sample times buffer
-        self.register_buffer("_sample_times",
-            torch.zeros(num_time_steps, dtype=self.dtype, device=self.device))
+        self.register_buffer(
+            "_sample_times",
+            torch.zeros(num_time_steps, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
         # Step 10 buffer: random phases
         # Shape: [batch_size, 1, 1, num_clusters, rays_per_cluster, 4]
-        self.register_buffer("_phi_buffer",
-            torch.zeros(batch_size, 1, 1, num_clusters, rays_per_cluster, 4,
-                       dtype=self.dtype, device=self.device))
+        self.register_buffer(
+            "_phi_buffer",
+            torch.zeros(
+                batch_size, 1, 1, num_clusters, rays_per_cluster, 4,
+                dtype=self.dtype, device=self.device,
+            ),
+            persistent=False,
+        )
 
         # Small zeros buffer for creating complex numbers
-        self.register_buffer("_zeros_buffer_small",
-            torch.zeros(1, dtype=self.dtype, device=self.device))
+        self.register_buffer(
+            "_zeros_buffer_small",
+            torch.zeros(1, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
     def __call__(
         self,
@@ -1059,4 +1076,3 @@ class ChannelCoefficientsGenerator(Object):
         h = torch.where(los_indicator, h_los, h_nlos)
 
         return h, delays_nlos
-

--- a/src/sionna/phy/fec/conv/decoding.py
+++ b/src/sionna/phy/fec/conv/decoding.py
@@ -155,7 +155,7 @@ class ViterbiDecoder(Block):
 
         # Pre-computed output bit patterns for branch metric calculation
         # Register buffer placeholder for CUDAGraph compatibility
-        self.register_buffer("_op_bits", None)
+        self.register_buffer("_op_bits", None, persistent=False)
 
     @property
     def gen_poly(self) -> Tuple[str, ...]:
@@ -403,8 +403,11 @@ class ViterbiDecoder(Block):
             [int2bin(op, self._conv_n) for op in range(self._no)]
         )
         # Register as buffer for CUDAGraph compatibility
-        self.register_buffer("_op_bits", torch.tensor(op_bits, dtype=self.dtype,
-                                     device=self.device))
+        self.register_buffer(
+            "_op_bits",
+            torch.tensor(op_bits, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
         # Move trellis to correct device if needed
         if self._trellis.device != self.device:
@@ -609,7 +612,7 @@ class BCJRDecoder(Block):
 
         # Pre-computed output bit patterns for branch metric calculation
         # Register buffer placeholder for CUDAGraph compatibility
-        self.register_buffer("_op_bits", None)
+        self.register_buffer("_op_bits", None, persistent=False)
 
     @property
     def gen_poly(self) -> Tuple[str, ...]:
@@ -902,8 +905,11 @@ class BCJRDecoder(Block):
             [int2bin(op, self._conv_n) for op in range(self._no)]
         )
         # Register as buffer for CUDAGraph compatibility
-        self.register_buffer("_op_bits", torch.tensor(op_bits, dtype=self.dtype,
-                                     device=self.device))
+        self.register_buffer(
+            "_op_bits",
+            torch.tensor(op_bits, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
         # Move trellis to correct device if needed
         if self._trellis.device != self.device:
@@ -978,4 +984,3 @@ class BCJRDecoder(Block):
 
         msghat_reshaped = msghat.reshape(output_shape)
         return msghat_reshaped
-

--- a/src/sionna/phy/fec/conv/utils.py
+++ b/src/sionna/phy/fec/conv/utils.py
@@ -119,7 +119,7 @@ def resolve_gen_poly(
     return polynomial_selector(rate, constraint_length)
 
 
-class Trellis:
+class Trellis(torch.nn.Module):
     r"""Trellis structure for a given generator polynomial.
 
     Defines state transitions and output symbols (and bits) for each current
@@ -158,6 +158,7 @@ class Trellis:
         rsc: bool = False,
         device: str = None,
     ):
+        super().__init__()
         self.rsc = rsc
         self.gen_poly = gen_poly
         self.constraint_length = len(self.gen_poly[0])
@@ -177,32 +178,37 @@ class Trellis:
             if self.conv_k != 1:
                 raise ValueError("RSC only supports conv_k=1.")
 
-        self._device = device if device is not None else "cpu"
+        resolved_device = device if device is not None else "cpu"
+        self.register_buffer(
+            "_device_ref",
+            torch.empty(0, device=resolved_device),
+            persistent=False,
+        )
 
         # For current state i and input j, state transitions i->to_nodes[i][j]
-        self.to_nodes = None
+        self.register_buffer("to_nodes", None, persistent=False)
 
         # For current state i, valid state transitions are from_nodes[i][:]-> i
-        self.from_nodes = None
+        self.register_buffer("from_nodes", None, persistent=False)
 
         # Given states i and j, Trellis emits op_mat[i][j] symbol if neq -1
-        self.op_mat = None
+        self.register_buffer("op_mat", None, persistent=False)
 
         # Given next state as i, trellis emits op_by_tonode[i][:] symbols
-        self.op_by_tonode = None
+        self.register_buffer("op_by_tonode", None, persistent=False)
 
         # Given ip_by_tonode[i][:] bits as input, trellis transitions to State i
-        self.ip_by_tonode = None
+        self.register_buffer("ip_by_tonode", None, persistent=False)
 
         # Given from state i and input j, trellis emits op_by_fromnode[i][j]
-        self.op_by_fromnode = None
+        self.register_buffer("op_by_fromnode", None, persistent=False)
 
         self._generate_transitions()
 
     @property
     def device(self) -> str:
         """Device on which trellis tensors reside."""
-        return self._device
+        return str(self._device_ref.device)
 
     @property
     def mu(self) -> int:
@@ -276,18 +282,36 @@ class Trellis:
                 op_by_fromnode[j][i] = op_sym
                 from_nodes_ctr[j_to] += 1
 
-        self.to_nodes = torch.tensor(to_nodes, dtype=torch.int32,
-                                     device=self._device)
-        self.from_nodes = torch.tensor(from_nodes, dtype=torch.int32,
-                                       device=self._device)
-        self.op_mat = torch.tensor(op_mat, dtype=torch.int32,
-                                   device=self._device)
-        self.ip_by_tonode = torch.tensor(ip_by_tonode, dtype=torch.int32,
-                                         device=self._device)
-        self.op_by_tonode = torch.tensor(op_by_tonode, dtype=torch.int32,
-                                         device=self._device)
-        self.op_by_fromnode = torch.tensor(op_by_fromnode, dtype=torch.int32,
-                                           device=self._device)
+        self.register_buffer(
+            "to_nodes",
+            torch.tensor(to_nodes, dtype=torch.int32, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "from_nodes",
+            torch.tensor(from_nodes, dtype=torch.int32, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "op_mat",
+            torch.tensor(op_mat, dtype=torch.int32, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "ip_by_tonode",
+            torch.tensor(ip_by_tonode, dtype=torch.int32, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "op_by_tonode",
+            torch.tensor(op_by_tonode, dtype=torch.int32, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "op_by_fromnode",
+            torch.tensor(op_by_fromnode, dtype=torch.int32, device=self.device),
+            persistent=False,
+        )
 
     def to(self, device: str) -> "Trellis":
         """Moves all tensors to the specified device.
@@ -296,14 +320,6 @@ class Trellis:
 
         :output trellis: Self reference for chaining.
         """
-        self._device = device
-        self.to_nodes = self.to_nodes.to(device)
-        self.from_nodes = self.from_nodes.to(device)
-        self.op_mat = self.op_mat.to(device)
-        self.ip_by_tonode = self.ip_by_tonode.to(device)
-        self.op_by_tonode = self.op_by_tonode.to(device)
-        self.op_by_fromnode = self.op_by_fromnode.to(device)
-        return self
-
+        return super().to(device)
 
 

--- a/src/sionna/phy/fec/crc.py
+++ b/src/sionna/phy/fec/crc.py
@@ -85,7 +85,7 @@ class CRCEncoder(Block):
         self._k: Optional[int] = None
         self._n: Optional[int] = None
         # Register buffer placeholder for CUDAGraph compatibility
-        self.register_buffer("_g_mat_crc", None)
+        self.register_buffer("_g_mat_crc", None, persistent=False)
         self._fixed_k: bool = False  # True if k was pre-specified
 
         # Pre-build generator matrix if k is specified
@@ -201,9 +201,11 @@ class CRCEncoder(Block):
             raise ValueError("Shape of last dimension cannot be None.")
         g_mat_crc = self._gen_crc_mat(k, self.crc_pol)
         # Register as buffer for CUDAGraph compatibility
-        self.register_buffer("_g_mat_crc", torch.tensor(
-            g_mat_crc, dtype=self.dtype, device=self.device
-        ))
+        self.register_buffer(
+            "_g_mat_crc",
+            torch.tensor(g_mat_crc, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
         self._k = k
         self._n = k + g_mat_crc.shape[1]
@@ -360,4 +362,3 @@ class CRCDecoder(Block):
         crc_valid = (x_parity_received == x_parity_computed).all(dim=-1, keepdim=True)
 
         return x_info, crc_valid
-

--- a/src/sionna/phy/fec/ldpc/decoding.py
+++ b/src/sionna/phy/fec/ldpc/decoding.py
@@ -385,22 +385,34 @@ class LDPCBPDecoder(Block):
         self._max_vn_degree = int(vn_degrees.max()) if len(vn_degrees) > 0 else 0
 
         # Build padded index arrays for vectorized operations
-        self._cn_gather_idx, self._cn_mask = self._build_padded_indices(
+        cn_gather_idx, cn_mask = self._build_padded_indices(
             cn_idx_sorted, cn_row_splits, self._num_cns, self._max_cn_degree
         )
-        self._vn_gather_idx, self._vn_mask = self._build_padded_indices(
+        self.register_buffer("_cn_gather_idx", cn_gather_idx, persistent=False)
+        self.register_buffer("_cn_mask", cn_mask, persistent=False)
+        vn_gather_idx, vn_mask = self._build_padded_indices(
             self._vn_idx, vn_row_splits, self._num_vns, self._max_vn_degree
         )
+        self.register_buffer("_vn_gather_idx", vn_gather_idx, persistent=False)
+        self.register_buffer("_vn_mask", vn_mask, persistent=False)
 
         # Build scatter indices for CN update
         # This maps from padded CN messages back to edge format
-        self._cn_scatter_idx = self._build_scatter_indices(
-            cn_row_splits, self._num_cns, self._max_cn_degree
+        self.register_buffer(
+            "_cn_scatter_idx",
+            self._build_scatter_indices(
+                cn_row_splits, self._num_cns, self._max_cn_degree
+            ),
+            persistent=False,
         )
 
         # Build scatter indices for VN update
-        self._vn_scatter_idx = self._build_scatter_indices(
-            vn_row_splits, self._num_vns, self._max_vn_degree
+        self.register_buffer(
+            "_vn_scatter_idx",
+            self._build_scatter_indices(
+                vn_row_splits, self._num_vns, self._max_vn_degree
+            ),
+            persistent=False,
         )
 
         # Precompute valid position indices for scatter operations (avoids dynamic shapes)

--- a/src/sionna/phy/fec/polar/encoding.py
+++ b/src/sionna/phy/fec/polar/encoding.py
@@ -106,7 +106,11 @@ class PolarEncoder(Block):
         self._check_input = True  # Check input for binary values during first call
 
         self._nb_stages = int(np.log2(self._n))
-        self._ind_gather = self._gen_indices(self._n)
+        self.register_buffer(
+            "_ind_gather",
+            self._gen_indices(self._n),
+            persistent=False,
+        )
 
     @property
     def k(self) -> int:
@@ -733,4 +737,3 @@ class Polar5GEncoder(PolarEncoder):
         c_reshaped = c_matched.reshape(output_shape)
 
         return c_reshaped
-

--- a/src/sionna/phy/fec/turbo/decoding.py
+++ b/src/sionna/phy/fec/turbo/decoding.py
@@ -128,7 +128,7 @@ class TurboDecoder(Block):
             self._gen_poly = encoder._gen_poly
             self._terminate = encoder.terminate
             self._trellis = encoder.trellis
-            if self._trellis._device != self.device:
+            if self._trellis.device != self.device:
                 self._trellis.to(self.device)
             if not self._trellis.rsc:
                 raise ValueError("Trellis must be RSC.")
@@ -194,8 +194,10 @@ class TurboDecoder(Block):
         self._coderate_conv = 1 / len(self._gen_poly)
         self._mu = len(self._gen_poly[0]) - 1
 
-        self._punct_pattern = puncture_pattern(
-            self._coderate, self._coderate_conv, device=self.device
+        self.register_buffer(
+            "_punct_pattern",
+            puncture_pattern(self._coderate, self._coderate_conv, device=self.device),
+            persistent=False,
         )
 
         # Number of input bit streams, only 1 in current implementation
@@ -417,7 +419,11 @@ class TurboDecoder(Block):
             )
 
         mask_ = mask_.reshape(-1)
-        self.register_buffer("_punct_indices", torch.where(mask_)[0].unsqueeze(-1).to(torch.int32))
+        self.register_buffer(
+            "_punct_indices",
+            torch.where(mask_)[0].unsqueeze(-1).to(torch.int32),
+            persistent=False,
+        )
 
     @torch.compiler.disable
     def call(self, llr_ch: torch.Tensor, /) -> torch.Tensor:
@@ -530,4 +536,3 @@ class TurboDecoder(Block):
 
         output_reshaped = output.reshape(output_shape)
         return output_reshaped
-

--- a/src/sionna/phy/fec/turbo/encoding.py
+++ b/src/sionna/phy/fec/turbo/encoding.py
@@ -152,8 +152,10 @@ class TurboEncoder(Block):
         rsc = True
 
         self._coderate_conv = 1 / len(self.gen_poly)
-        self._punct_pattern = puncture_pattern(
-            rate, self._coderate_conv, device=self.device
+        self.register_buffer(
+            "_punct_pattern",
+            puncture_pattern(rate, self._coderate_conv, device=self.device),
+            persistent=False,
         )
 
         self._trellis = Trellis(self.gen_poly, rsc=rsc, device=self.device)
@@ -194,7 +196,10 @@ class TurboEncoder(Block):
 
         # Precompute puncture indices
         if self._punct_pattern is not None:
-            self.register_buffer("_punct_idx", torch.where(self._punct_pattern.flatten())[0])
+            self.register_buffer(
+                "_punct_idx",
+                torch.where(self._punct_pattern.flatten())[0],
+            )
         else:
             self.register_buffer("_punct_idx", None)
 
@@ -435,4 +440,3 @@ class TurboEncoder(Block):
         cw_reshaped = cw.reshape(output_shape)
         # Ensure contiguous output for torch.compile compatibility
         return cw_reshaped.contiguous()
-

--- a/src/sionna/phy/mapping.py
+++ b/src/sionna/phy/mapping.py
@@ -339,7 +339,7 @@ class Constellation(Block):
             raise ValueError("You must provide a value for `points`")
 
         # Initialize _points placeholder (will be set by property setter)
-        self._points = None
+        self.register_buffer("_points", None, persistent=False)
         if self.constellation_type == "qam":
             points = qam(self.num_bits_per_symbol, normalize=True, precision=precision)
         elif self.constellation_type == "pam":
@@ -396,16 +396,32 @@ class Constellation(Block):
             if v.shape != torch.Size([2**self.num_bits_per_symbol]):
                 err_msg = "`points` must have shape [2**num_bits_per_symbol]"
                 raise ValueError(err_msg)
+            is_parameter = isinstance(v, torch.nn.Parameter)
+            requires_grad = v.requires_grad
             # Use .to() to preserve gradient flow for trainable constellations
             if v.dtype != self.cdtype or v.device != torch.device(self.device):
                 v = v.to(dtype=self.cdtype, device=self.device)
-            self._points = v
+            self._parameters.pop("_points", None)
+            self._buffers.pop("_points", None)
+            if is_parameter:
+                if isinstance(v, torch.nn.Parameter):
+                    self._points = v
+                else:
+                    self._points = torch.nn.Parameter(v, requires_grad=requires_grad)
+            else:
+                self.register_buffer("_points", v, persistent=False)
         else:
             # Convert numpy array to tensor
             if np.shape(v) != (2**self.num_bits_per_symbol,):
                 err_msg = "`points` must have shape [2**num_bits_per_symbol]"
                 raise ValueError(err_msg)
-            self._points = torch.tensor(v, dtype=self.cdtype, device=self.device)
+            self._parameters.pop("_points", None)
+            self._buffers.pop("_points", None)
+            self.register_buffer(
+                "_points",
+                torch.tensor(v, dtype=self.cdtype, device=self.device),
+                persistent=False,
+            )
 
     def call(self) -> torch.Tensor:
         x = self.points
@@ -541,8 +557,10 @@ class Mapper(Block):
         )
         self._return_indices = return_indices
         n = self.constellation.num_bits_per_symbol
-        self._bit_positions = torch.arange(
-            n - 1, -1, -1, dtype=torch.int32, device=self.device
+        self.register_buffer(
+            "_bit_positions",
+            torch.arange(n - 1, -1, -1, dtype=torch.int32, device=self.device),
+            persistent=False,
         )
 
     @property
@@ -720,7 +738,11 @@ class Demapper(Block):
         )
 
         tiny = np.finfo(dtypes[self.precision]["np"]["dtype"]).tiny
-        self._no_threshold = torch.tensor(tiny, dtype=self.dtype, device=self.device)
+        self.register_buffer(
+            "_no_threshold",
+            torch.tensor(tiny, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
     @property
     def constellation(self) -> Constellation:
@@ -992,13 +1014,25 @@ class SymbolLogits2LLRs(Block):
         # [num_points/2, num_bits_per_symbol]
         c0 = np.array([np.where(a[:, i] == 0)[0] for i in range(num_bits_per_symbol)]).T
         c1 = np.array([np.where(a[:, i] == 1)[0] for i in range(num_bits_per_symbol)]).T
-        self._c0 = torch.tensor(c0, dtype=torch.int64, device=self.device)
-        self._c1 = torch.tensor(c1, dtype=torch.int64, device=self.device)
+        self.register_buffer(
+            "_c0",
+            torch.tensor(c0, dtype=torch.int64, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_c1",
+            torch.tensor(c1, dtype=torch.int64, device=self.device),
+            persistent=False,
+        )
 
         # Array of labels from {-1, 1} of all symbols
         # [num_points, num_bits_per_symbol]
         a = 2 * a - 1
-        self._a = torch.tensor(a, dtype=self.dtype, device=self.device)
+        self.register_buffer(
+            "_a",
+            torch.tensor(a, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
     @property
     def num_bits_per_symbol(self) -> int:
@@ -1130,7 +1164,11 @@ class LLRs2SymbolLogits(Block):
 
         # Binary labels from {-1, 1} of all symbols [num_points, num_bits_per_symbol]
         a = 2 * _compute_binary_labels(num_bits_per_symbol) - 1
-        self._a = torch.tensor(a, dtype=self.dtype, device=self.device)
+        self.register_buffer(
+            "_a",
+            torch.tensor(a, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
     @property
     def num_bits_per_symbol(self) -> int:
@@ -1279,7 +1317,11 @@ class SymbolInds2Bits(Block):
         super().__init__(precision=precision, device=device, **kwargs)
         # Binary representation of all symbol indices [num_symbols, num_bits_per_symbol]
         b = _compute_binary_labels(num_bits_per_symbol)
-        self._bit_labels = torch.tensor(b, dtype=self.dtype, device=self.device)
+        self.register_buffer(
+            "_bit_labels",
+            torch.tensor(b, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
     def call(self, symbol_ind: torch.Tensor) -> torch.Tensor:
         return self._bit_labels[symbol_ind]
@@ -1338,8 +1380,16 @@ class QAM2PAM(Object):
         pam1_ind = (bits[:, 0::2] * base).sum(axis=1)
         pam2_ind = (bits[:, 1::2] * base).sum(axis=1)
 
-        self._pam1_ind = torch.tensor(pam1_ind, dtype=torch.int64, device=self.device)
-        self._pam2_ind = torch.tensor(pam2_ind, dtype=torch.int64, device=self.device)
+        self.register_buffer(
+            "_pam1_ind",
+            torch.tensor(pam1_ind, dtype=torch.int64, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_pam2_ind",
+            torch.tensor(pam2_ind, dtype=torch.int64, device=self.device),
+            persistent=False,
+        )
 
     def __call__(self, ind_qam: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
         ind_pam1 = self._pam1_ind[ind_qam]
@@ -1416,7 +1466,11 @@ class PAM2QAM(Object):
         qam_base = np.array([2**k for k in range(num_bits_per_symbol - 1, -1, -1)])
         ind = (interleaved * qam_base).sum(axis=-1)
 
-        self._qam_ind = torch.tensor(ind, dtype=torch.int64, device=self.device)
+        self.register_buffer(
+            "_qam_ind",
+            torch.tensor(ind, dtype=torch.int64, device=self.device),
+            persistent=False,
+        )
         self._hard_in_out = hard_in_out
 
     def __call__(self, pam1: torch.Tensor, pam2: torch.Tensor) -> torch.Tensor:

--- a/src/sionna/phy/mimo/detection.py
+++ b/src/sionna/phy/mimo/detection.py
@@ -400,11 +400,21 @@ class MaximumLikelihoodDetector(Block):
 
         # Build lookup tables
         vecs, vecs_ind, c = self._build_vecs(num_streams)
-        self._vecs = torch.as_tensor(vecs, dtype=self.cdtype, device=self.device)
-        self._vecs_ind = torch.as_tensor(
-            vecs_ind, dtype=torch.int64, device=self.device
+        self.register_buffer(
+            "_vecs",
+            torch.as_tensor(vecs, dtype=self.cdtype, device=self.device),
+            persistent=False,
         )
-        self._c = torch.as_tensor(c, dtype=torch.int64, device=self.device)
+        self.register_buffer(
+            "_vecs_ind",
+            torch.as_tensor(vecs_ind, dtype=torch.int64, device=self.device),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_c",
+            torch.as_tensor(c, dtype=torch.int64, device=self.device),
+            persistent=False,
+        )
 
         if output == "bit":
             num_bits = self._constellation.num_bits_per_symbol
@@ -727,7 +737,11 @@ class KBestDetector(Block):
                 device=device,
             )
             c._points = c._points / (torch.std(c._points).item() * np.sqrt(2))
-            self._constellation = c.points.real.to(self.dtype)
+            self.register_buffer(
+                "_constellation",
+                c.points.real.to(self.dtype),
+                persistent=False,
+            )
 
             self._pam2qam = PAM2QAM(
                 2 * self._num_bits_per_symbol, precision=precision, device=device
@@ -742,7 +756,7 @@ class KBestDetector(Block):
                 precision=precision,
                 device=device,
             )
-            self._constellation = c()
+            self.register_buffer("_constellation", c(), persistent=False)
             self._num_bits_per_symbol = c.num_bits_per_symbol
 
         self._num_symbols = self._constellation.shape[0]
@@ -766,15 +780,23 @@ class KBestDetector(Block):
             ind[:, : l + 1] = 1
             ind = np.stack(np.where(ind), -1)
             indices[l, : ind.shape[0], : ind.shape[1]] = ind
-        self._indices = torch.tensor(indices, dtype=torch.int64, device=self.device)
+        self.register_buffer(
+            "_indices",
+            torch.tensor(indices, dtype=torch.int64, device=self.device),
+            persistent=False,
+        )
 
         # Precompute symbol patterns for each layer to avoid recreating in loop
         # Symbol pattern: [k, num_symbols] -> tiled constellation
-        self._sym_pattern = (
-            self._constellation.reshape(1, -1).expand(self._k, -1).reshape(-1)
+        self.register_buffer(
+            "_sym_pattern",
+            self._constellation.reshape(1, -1).expand(self._k, -1).reshape(-1),
+            persistent=False,
         )
-        self._ind_pattern = torch.arange(self._num_symbols, device=self.device).repeat(
-            self._k
+        self.register_buffer(
+            "_ind_pattern",
+            torch.arange(self._num_symbols, device=self.device).repeat(self._k),
+            persistent=False,
         )
 
         if self._output == "bit":
@@ -1168,13 +1190,23 @@ class EPDetector(Block):
         points = Constellation(
             "pam", int(self._num_bits_per_symbol), precision=precision, device=device
         )()
-        self._points = (points / np.sqrt(2.0)).real.to(self.dtype)
-        self._es = torch.tensor(
-            self._points.var().item(), dtype=self.dtype, device=self.device
+        self.register_buffer(
+            "_points",
+            (points / np.sqrt(2.0)).real.to(self.dtype),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_es",
+            torch.tensor(self._points.var().item(), dtype=self.dtype, device=self.device),
+            persistent=False,
         )
 
         # Pre-compute scalar for noise
-        self._no = torch.tensor(0.5, dtype=self.dtype, device=self.device)
+        self.register_buffer(
+            "_no",
+            torch.tensor(0.5, dtype=self.dtype, device=self.device),
+            persistent=False,
+        )
 
     def compute_sigma_mu(self, h_t_h, h_t_y, no, lam, gam):
         """Equations (28) and (29)."""

--- a/src/sionna/phy/mimo/utils.py
+++ b/src/sionna/phy/mimo/utils.py
@@ -547,9 +547,17 @@ class List2LLRSimple(List2LLR):
         # Convert to tensor and add dummy dimensions needed for broadcasting
         # Shape: [1, 1, 1, num_points/2, num_bits_per_symbol]
         c0_tensor = torch.tensor(c0, dtype=torch.int32, device=self.device)
-        self._c0 = expand_to_rank(c0_tensor, 5, 0)
+        self.register_buffer(
+            "_c0",
+            expand_to_rank(c0_tensor, 5, 0),
+            persistent=False,
+        )
         c1_tensor = torch.tensor(c1, dtype=torch.int32, device=self.device)
-        self._c1 = expand_to_rank(c1_tensor, 5, 0)
+        self.register_buffer(
+            "_c1",
+            expand_to_rank(c1_tensor, 5, 0),
+            persistent=False,
+        )
 
         # Assign this absolute value to all LLRs without counter-hypothesis
         self._llr_clip_val = llr_clip_val
@@ -620,4 +628,3 @@ class List2LLRSimple(List2LLR):
         llr = llr.clamp(-self._llr_clip_val, self._llr_clip_val)
 
         return llr
-

--- a/src/sionna/phy/nr/pusch_pilot_pattern.py
+++ b/src/sionna/phy/nr/pusch_pilot_pattern.py
@@ -32,6 +32,8 @@ class PUSCHPilotPattern(PilotPattern):
         Precision used for internal calculations and outputs.
         If set to `None`,
         :attr:`~sionna.phy.config.Config.precision` is used.
+    :param device: Device for tensor operations. If `None`,
+        :attr:`~sionna.phy.config.Config.device` is used.
 
     .. rubric:: Examples
 
@@ -48,6 +50,7 @@ class PUSCHPilotPattern(PilotPattern):
         self,
         pusch_configs: Union[PUSCHConfig, List[PUSCHConfig]],
         precision: Optional[str] = None,
+        device: Optional[str] = None,
     ):
         # Check correct type of pusch_configs
         if isinstance(pusch_configs, PUSCHConfig):
@@ -111,5 +114,6 @@ class PUSCHPilotPattern(PilotPattern):
                 pilots[i, j] = dmrs_grid[np.where(mask[i, j])]
 
         # Init PilotPattern class
-        super().__init__(mask, pilots, normalize=False, precision=precision)
-
+        super().__init__(
+            mask, pilots, normalize=False, precision=precision, device=device
+        )

--- a/src/sionna/phy/nr/pusch_transmitter.py
+++ b/src/sionna/phy/nr/pusch_transmitter.py
@@ -121,7 +121,14 @@ class PUSCHTransmitter(Block):
 
         params = check_pusch_configs(pusch_configs)
         for key, value in params.items():
-            setattr(self, f"_{key}", value)
+            if isinstance(value, torch.Tensor):
+                self.register_buffer(
+                    f"_{key}",
+                    value.to(device=self.device),
+                    persistent=False,
+                )
+            else:
+                setattr(self, f"_{key}", value)
 
         self._pusch_configs = pusch_configs
 
@@ -166,6 +173,7 @@ class PUSCHTransmitter(Block):
         self._pilot_pattern = PUSCHPilotPattern(
             self._pusch_configs,
             precision=self.precision,
+            device=self.device,
         )
 
         # Create ResourceGrid
@@ -268,4 +276,3 @@ class PUSCHTransmitter(Block):
         if self._return_bits:
             return x, b
         return x
-

--- a/src/sionna/phy/nr/tb_decoder.py
+++ b/src/sionna/phy/nr/tb_decoder.py
@@ -143,7 +143,11 @@ class TBDecoder(Block):
             self._cb_crc_decoder = None
 
         # Cache output_perm_inv on decoder's device to avoid .to() on every call
-        self._output_perm_inv = encoder.output_perm_inv.to(self.device)
+        self.register_buffer(
+            "_output_perm_inv",
+            encoder.output_perm_inv.to(self.device),
+            persistent=False,
+        )
 
     #########################################
     # Public methods and properties
@@ -241,4 +245,3 @@ class TBDecoder(Block):
         tb_crc_status = tb_crc_status.squeeze(-1).bool()
 
         return u_hat, tb_crc_status
-

--- a/src/sionna/phy/nr/tb_encoder.py
+++ b/src/sionna/phy/nr/tb_encoder.py
@@ -151,7 +151,14 @@ class TBEncoder(Block):
 
         if not (0. < target_coderate <= 948 / 1024):
             raise ValueError("target_coderate must be in range (0, 0.925].")
-        self._target_coderate = target_coderate
+        if isinstance(target_coderate, torch.Tensor):
+            self.register_buffer(
+                "_target_coderate",
+                target_coderate.to(dtype=self.dtype, device=self.device),
+                persistent=False,
+            )
+        else:
+            self._target_coderate = target_coderate
 
         if num_bits_per_symbol % 1 != 0:
             raise ValueError("num_bits_per_symbol must be int.")
@@ -457,4 +464,3 @@ class TBEncoder(Block):
         c_tb = c_scr.reshape(output_shape)
 
         return c_tb
-

--- a/src/sionna/phy/object.py
+++ b/src/sionna/phy/object.py
@@ -42,8 +42,12 @@ class Object(torch.nn.Module):
         self._precision: Precision = (
             config.precision if precision is None else precision
         )
-        # Use _device_str to avoid conflict with nn.Module internals
-        self._device_str: str = config.device if device is None else device
+        resolved_device = config.device if device is None else device
+        self.register_buffer(
+            "_device_ref",
+            torch.empty(0, device=resolved_device),
+            persistent=False,
+        )
 
     @property
     def dtype(self) -> torch.dtype:
@@ -73,7 +77,7 @@ class Object(torch.nn.Module):
     @property
     def device(self) -> str:
         """Get the device for computation (e.g., 'cpu', 'cuda:0')."""
-        return self._device_str
+        return str(self._device_ref.device)
 
     @property
     def torch_rng(self) -> torch.Generator:
@@ -108,7 +112,7 @@ class Object(torch.nn.Module):
         # Convert floats and complex to tensors (data values)
         # Also convert numpy arrays and other array-like objects
         if not isinstance(v, torch.Tensor):
-            v = torch.as_tensor(v, device=self._device_str)
+            v = torch.as_tensor(v, device=self.device)
 
         # Determine target dtype
         if v.is_complex():

--- a/src/sionna/phy/ofdm/channel_estimation.py
+++ b/src/sionna/phy/ofdm/channel_estimation.py
@@ -154,7 +154,11 @@ class BaseChannelEstimator(Block):
         # Use stable=True to ensure consistent ordering across CPU/GPU
         # (otherwise ties among pilot positions may be ordered differently)
         pilot_ind = torch.argsort(mask.float(), dim=-1, descending=True, stable=True)
-        self._pilot_ind = pilot_ind[..., :num_pilot_symbols].to(device=self.device)
+        self.register_buffer(
+            "_pilot_ind",
+            pilot_ind[..., :num_pilot_symbols].to(device=self.device),
+            persistent=False,
+        )
 
     @abstractmethod
     def estimate_at_pilot_locations(
@@ -434,12 +438,15 @@ class NearestNeighborInterpolator(BaseChannelInterpolator):
                     # Store it in the index tensor
                     gather_ind[a, i, j] = ind
 
-        # Reshape to the original shape of the mask
-        # Store on the configured device directly (no buffer needed)
-        from sionna.phy import config
-
-        self._gather_ind = torch.tensor(
-            np.reshape(gather_ind, mask_shape), dtype=torch.int64, device=config.device
+        # Reshape to the original shape of the mask.
+        self.register_buffer(
+            "_gather_ind",
+            torch.tensor(
+                np.reshape(gather_ind, mask_shape),
+                dtype=torch.int64,
+                device=self.device,
+            ),
+            persistent=False,
         )
 
     def _interpolate(self, inputs: torch.Tensor) -> torch.Tensor:

--- a/src/sionna/phy/ofdm/demodulator.py
+++ b/src/sionna/phy/ofdm/demodulator.py
@@ -109,7 +109,7 @@ class OFDMDemodulator(Block):
         self.register_buffer("_phase_compensation", None)
         # Store symbol_length as buffer for torch.compile compatibility
         self.register_buffer("_symbol_length", None)
-        self.register_buffer("_ind", None)
+        self.register_buffer("_ind", None, persistent=False)
 
         self.fft_size = fft_size
         self.l_min = l_min
@@ -224,7 +224,11 @@ class OFDMDemodulator(Block):
                 indices_list.append(indices)
 
             # [num_ofdm_symbols, fft_size]
-            self.register_buffer("_ind", torch.stack(indices_list, dim=0))
+            self.register_buffer(
+                "_ind",
+                torch.stack(indices_list, dim=0),
+                persistent=False,
+            )
 
     def call(self, inputs: torch.Tensor) -> torch.Tensor:
         """Demodulate OFDM waveform onto a resource grid."""

--- a/src/sionna/phy/ofdm/detection.py
+++ b/src/sionna/phy/ofdm/detection.py
@@ -163,21 +163,37 @@ class OFDMDetector(Block):
             flatten_last_dims(mask.to(torch.float32)), dim=-1, descending=False,
             stable=True
         )
-        self._data_ind = data_ind[..., :num_data_symbols].to(device=self.device)
+        self.register_buffer(
+            "_data_ind",
+            data_ind[..., :num_data_symbols].to(device=self.device),
+            persistent=False,
+        )
 
         # Precompute stream management indices as tensors for CUDA Graph compatibility
-        self._detection_desired_ind = torch.tensor(
-            stream_management.detection_desired_ind,
-            dtype=torch.long,
-            device=self.device,
+        self.register_buffer(
+            "_detection_desired_ind",
+            torch.tensor(
+                stream_management.detection_desired_ind,
+                dtype=torch.long,
+                device=self.device,
+            ),
+            persistent=False,
         )
-        self._detection_undesired_ind = torch.tensor(
-            stream_management.detection_undesired_ind,
-            dtype=torch.long,
-            device=self.device,
+        self.register_buffer(
+            "_detection_undesired_ind",
+            torch.tensor(
+                stream_management.detection_undesired_ind,
+                dtype=torch.long,
+                device=self.device,
+            ),
+            persistent=False,
         )
-        self._stream_ind = torch.tensor(
-            stream_management.stream_ind, dtype=torch.long, device=self.device
+        self.register_buffer(
+            "_stream_ind",
+            torch.tensor(
+                stream_management.stream_ind, dtype=torch.long, device=self.device
+            ),
+            persistent=False,
         )
 
     def _preprocess_inputs(
@@ -510,7 +526,7 @@ class OFDMDetectorWithPrior(OFDMDetector):
 
         # Track allocated batch size for CUDAGraph compatibility
         self._allocated_batch_size = None
-        self.register_buffer("_template", None)
+        self.register_buffer("_template", None, persistent=False)
 
     def build(self, y_shape, h_hat_shape, prior_shape, err_var_shape, no_shape):
         """Pre-allocate buffers based on input shapes.
@@ -548,6 +564,7 @@ class OFDMDetectorWithPrior(OFDMDetector):
                 dtype=self.dtype,
                 device=self.device,
             ),
+            persistent=False,
         )
 
     def call(

--- a/src/sionna/phy/ofdm/equalization.py
+++ b/src/sionna/phy/ofdm/equalization.py
@@ -136,23 +136,39 @@ class OFDMEqualizer(Block):
             flatten_last_dims(mask.to(torch.float32)), dim=-1, descending=False,
             stable=True
         )
-        self._data_ind = data_ind[..., :num_data_symbols].to(device=self.device)
+        self.register_buffer(
+            "_data_ind",
+            data_ind[..., :num_data_symbols].to(device=self.device),
+            persistent=False,
+        )
 
         # Precompute stream management indices as tensors for CUDA Graph compatibility
-        self._detection_desired_ind = torch.tensor(
-            stream_management.detection_desired_ind,
-            dtype=torch.long,
-            device=self.device
+        self.register_buffer(
+            "_detection_desired_ind",
+            torch.tensor(
+                stream_management.detection_desired_ind,
+                dtype=torch.long,
+                device=self.device,
+            ),
+            persistent=False,
         )
-        self._detection_undesired_ind = torch.tensor(
-            stream_management.detection_undesired_ind,
-            dtype=torch.long,
-            device=self.device
+        self.register_buffer(
+            "_detection_undesired_ind",
+            torch.tensor(
+                stream_management.detection_undesired_ind,
+                dtype=torch.long,
+                device=self.device,
+            ),
+            persistent=False,
         )
-        self._stream_ind = torch.tensor(
-            stream_management.stream_ind,
-            dtype=torch.long,
-            device=self.device
+        self.register_buffer(
+            "_stream_ind",
+            torch.tensor(
+                stream_management.stream_ind,
+                dtype=torch.long,
+                device=self.device,
+            ),
+            persistent=False,
         )
 
     def call(
@@ -862,4 +878,3 @@ class LMMSEPostEqualizationSINR(PostEqualizationSINR):
         )
 
         return sinr
-

--- a/src/sionna/phy/ofdm/modulator.py
+++ b/src/sionna/phy/ofdm/modulator.py
@@ -59,7 +59,7 @@ class OFDMModulator(Block):
         self._cp_length_scalar: Optional[int] = None  # Cached scalar for call()
         # Register tensors as buffers for CUDA graph compatibility
         self.register_buffer("_cyclic_prefix_length", None)
-        self.register_buffer("_ind", None)
+        self.register_buffer("_ind", None, persistent=False)
         self.cyclic_prefix_length = cyclic_prefix_length
 
     @property
@@ -134,7 +134,7 @@ class OFDMModulator(Block):
                 offset += cp_length_i + fft_size
 
             # Concatenate all indices
-            self.register_buffer("_ind", torch.cat(indices_list))
+            self.register_buffer("_ind", torch.cat(indices_list), persistent=False)
 
     def call(self, inputs: torch.Tensor) -> torch.Tensor:
         """Modulate OFDM resource grid to time-domain signal.

--- a/src/sionna/phy/ofdm/resource_grid.py
+++ b/src/sionna/phy/ofdm/resource_grid.py
@@ -462,9 +462,19 @@ class ResourceGridMapper(Block):
         # [num_tx, num_streams_per_tx, num_ofdm_symbols, fft_size]
         # which is prefilled with pilots and stores indices
         # to scatter data symbols.
-        self._rg_type = self._resource_grid.build_type_grid()
-        self.register_buffer("_pilot_ind", torch.nonzero(self._rg_type == 1, as_tuple=False))
-        self.register_buffer("_data_ind", torch.nonzero(self._rg_type == 0, as_tuple=False))
+        self.register_buffer(
+            "_rg_type",
+            self._resource_grid.build_type_grid(),
+            persistent=False,
+        )
+        self.register_buffer(
+            "_pilot_ind",
+            torch.nonzero(self._rg_type == 1, as_tuple=False),
+        )
+        self.register_buffer(
+            "_data_ind",
+            torch.nonzero(self._rg_type == 0, as_tuple=False),
+        )
 
     def call(self, inputs: torch.Tensor) -> torch.Tensor:
         """Map data symbols to resource grid.
@@ -713,4 +723,3 @@ class RemoveNulledSubcarriers(Block):
         """
         # Use index_select for torch.compile compatibility
         return torch.index_select(inputs, -1, self._sc_ind)
-

--- a/src/sionna/phy/signal/filter.py
+++ b/src/sionna/phy/signal/filter.py
@@ -109,7 +109,7 @@ class Filter(Block):
         assert isinstance(normalize, bool), "normalize must be bool"
         self._normalize = normalize
 
-        self._coefficients: Optional[torch.Tensor] = None
+        self.register_buffer("_coefficients", None, persistent=False)
 
     @property
     def span_in_symbols(self) -> int:
@@ -174,15 +174,29 @@ class Filter(Block):
 
     @coefficients.setter
     def coefficients(self, v: Union[torch.Tensor, np.ndarray]) -> None:
+        is_parameter = False
+        requires_grad = False
         if not isinstance(v, torch.Tensor):
             v = torch.as_tensor(v, dtype=self.dtype, device=self.device)
         else:
+            is_parameter = isinstance(v, torch.nn.Parameter)
+            requires_grad = v.requires_grad
             # Preserve gradient if already a tensor with requires_grad
             # Only convert if dtype or device differs
             target_dtype = self.cdtype if v.is_complex() else self.dtype
             if v.dtype != target_dtype or str(v.device) != self.device:
                 v = v.to(dtype=target_dtype, device=self.device)
-        self._coefficients = v
+        self._parameters.pop("_coefficients", None)
+        self._buffers.pop("_coefficients", None)
+        if is_parameter:
+            if isinstance(v, torch.nn.Parameter):
+                self._coefficients = v
+            else:
+                self._coefficients = torch.nn.Parameter(
+                    v, requires_grad=requires_grad
+                )
+        else:
+            self.register_buffer("_coefficients", v, persistent=False)
 
     @property
     def sampling_times(self) -> np.ndarray:

--- a/src/sionna/phy/signal/window.py
+++ b/src/sionna/phy/signal/window.py
@@ -72,7 +72,7 @@ class Window(Block):
         super().__init__(precision=precision, device=device, **kwargs)
         assert isinstance(normalize, bool), "normalize must be bool"
         self._normalize = normalize
-        self._coefficients: Optional[torch.Tensor] = None
+        self.register_buffer("_coefficients", None, persistent=False)
 
     @property
     def coefficients(self) -> torch.Tensor:
@@ -81,14 +81,28 @@ class Window(Block):
 
     @coefficients.setter
     def coefficients(self, v: Union[torch.Tensor, np.ndarray]) -> None:
+        is_parameter = False
+        requires_grad = False
         if not isinstance(v, torch.Tensor):
             v = torch.as_tensor(v, dtype=self.dtype, device=self.device)
         else:
+            is_parameter = isinstance(v, torch.nn.Parameter)
+            requires_grad = v.requires_grad
             # Preserve gradient if already a tensor with requires_grad
             # Only convert if dtype or device differs
             if v.dtype != self.dtype or str(v.device) != self.device:
                 v = v.to(dtype=self.dtype, device=self.device)
-        self._coefficients = v
+        self._parameters.pop("_coefficients", None)
+        self._buffers.pop("_coefficients", None)
+        if is_parameter:
+            if isinstance(v, torch.nn.Parameter):
+                self._coefficients = v
+            else:
+                self._coefficients = torch.nn.Parameter(
+                    v, requires_grad=requires_grad
+                )
+        else:
+            self.register_buffer("_coefficients", v, persistent=False)
 
     @property
     def length(self) -> int:

--- a/test/unit/channel/test_awgn.py
+++ b/test/unit/channel/test_awgn.py
@@ -4,6 +4,7 @@
 #
 """Tests for the AWGN channel block"""
 
+import pytest
 import torch
 
 from sionna.phy import dtypes
@@ -138,3 +139,35 @@ class TestAWGN:
         y = awgn(x, no)
 
         assert y.device == x.device
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_to_cuda_updates_logical_device_and_output_device(self):
+        """Test that AWGN follows .to(cuda) even without other tensor state."""
+        awgn = AWGN(device="cpu")
+
+        awgn.to("cuda:0")
+
+        x = torch.randn(8, 4, dtype=torch.complex64, device="cuda:0")
+        y = awgn(x, 0.1)
+        assert awgn.device == "cuda:0"
+        assert y.device == torch.device("cuda:0")
+
+    @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+    def test_parent_module_to_cuda_updates_child_awgn(self):
+        """Test that a parent nn.Module moves child AWGN's device buffer."""
+
+        class Parent(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.awgn = AWGN(device="cpu")
+
+            def forward(self, x, no):
+                return self.awgn(x, no)
+
+        parent = Parent()
+        parent.to("cuda:0")
+
+        x = torch.randn(8, 4, dtype=torch.complex64, device="cuda:0")
+        y = parent(x, 0.1)
+        assert parent.awgn.device == "cuda:0"
+        assert y.device == torch.device("cuda:0")

--- a/test/unit/ofdm/test_ofdm_demodulator.py
+++ b/test/unit/ofdm/test_ofdm_demodulator.py
@@ -35,6 +35,22 @@ class TestOFDMDemodulator:
 
             assert torch.max(torch.abs(x - x_hat)) < 1e-5
 
+    def test_default_cyclic_prefix(self, device, precision):
+        """Test demodulation with the default scalar cyclic prefix length"""
+        fft_size = 72
+        num_ofdm_symbols = 14
+        qam_source = QAMSource(4, precision=precision, device=device)
+
+        modulator = OFDMModulator(precision=precision, device=device)
+        demodulator = OFDMDemodulator(
+            fft_size, 0, precision=precision, device=device
+        )
+        x = qam_source([4, num_ofdm_symbols, fft_size])
+        x_time = modulator(x)
+        x_hat = demodulator(x_time)
+
+        assert torch.max(torch.abs(x - x_hat)) < 1e-5
+
     def test_higher_dimensions(self, device, precision):
         """Test demodulator with higher dimensional inputs"""
         batch_size = [64, 12, 6]
@@ -237,4 +253,3 @@ class TestOFDMModDemod:
             assert x_f.shape == torch.Size(
                 [32, 1, 1, num_ofdm_symbols, fft_size]
             )
-

--- a/test/unit/signal/test_filter.py
+++ b/test/unit/signal/test_filter.py
@@ -283,6 +283,27 @@ class TestCustomFilter:
         else:
             assert fil_coeff.grad.sum().item() != 0
 
+    def test_parameter_coefficients_are_trainable(self, device):
+        """Test that Parameter coefficients remain module parameters"""
+        samples_per_symbol = 4
+        filter_length = samples_per_symbol * 8 + 1
+        rdtype = dtypes["double"]["torch"]["dtype"]
+        coeff = torch.nn.Parameter(
+            torch.randn(filter_length, dtype=rdtype, device=device)
+        )
+
+        filt = CustomFilter(
+            samples_per_symbol,
+            coefficients=coeff,
+            precision="double",
+            device=device,
+        )
+
+        params = list(filt.parameters())
+        assert len(params) == 1
+        assert params[0] is coeff
+        assert "_coefficients" in filt.state_dict()
+
 
 class TestRaisedCosineFilter:
     """Tests for the RaisedCosineFilter class"""

--- a/test/unit/signal/test_window.py
+++ b/test/unit/signal/test_window.py
@@ -103,6 +103,21 @@ class TestCustomWindow:
         assert coeff.grad.shape == coeff.shape
         assert coeff.grad.sum().item() != 0
 
+    def test_parameter_coefficients_are_trainable(self, device):
+        """Test that Parameter coefficients remain module parameters"""
+        win_length = 128
+        rdtype = dtypes["single"]["torch"]["dtype"]
+        coeff = torch.nn.Parameter(
+            torch.randn(win_length, dtype=rdtype, device=device)
+        )
+
+        window = CustomWindow(coeff, precision="single", device=device)
+
+        params = list(window.parameters())
+        assert len(params) == 1
+        assert params[0] is coeff
+        assert "_coefficients" in window.state_dict()
+
 
 class TestHannWindow:
     """Tests for the HannWindow class"""

--- a/test/unit/test_mapping.py
+++ b/test/unit/test_mapping.py
@@ -254,6 +254,28 @@ class TestConstellation:
         assert np.isclose(output.mean().abs().item(), 0.0, atol=1e-5)
         assert np.isclose((output.abs() ** 2).mean().item(), 1.0, atol=1e-5)
 
+    def test_custom_parameter_points_are_trainable(self, device):
+        """Verify custom Parameter points remain module parameters."""
+        points = torch.nn.Parameter(
+            torch.tensor(
+                [1 + 1j, -1 + 1j, 1 - 1j, -1 - 1j],
+                dtype=torch.complex64,
+                device=device,
+            )
+        )
+        c = Constellation(
+            "custom", 2, points=points, precision="single", device=device
+        )
+
+        params = list(c.parameters())
+        assert len(params) == 1
+        assert params[0] is points
+        assert "_points" in c.state_dict()
+
+        loss = c().abs().square().sum()
+        loss.backward()
+        assert points.grad is not None
+
     def test_dtype(self, precision, device):
         """Verify output dtype matches requested precision."""
         c = Constellation("qam", 4, precision=precision, device=device)

--- a/test/unit/test_object.py
+++ b/test/unit/test_object.py
@@ -8,6 +8,16 @@ import numpy as np
 from sionna.phy import config, dtypes, Object
 
 
+class _BufferObject(Object):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.register_buffer(
+            "_cache",
+            torch.ones(1, device=self.device),
+            persistent=False,
+        )
+
+
 def test_default_properties():
     obj = Object()
     assert obj.precision == config.precision
@@ -34,6 +44,40 @@ def test_device_setter(device):
     obj = Object(device=device)
     assert obj.device == device
     assert obj.torch_rng == config.torch_rng(device)
+
+
+def test_device_is_derived_from_non_persistent_buffer():
+    obj = Object(device="cpu")
+    buffers = dict(obj.named_buffers())
+
+    assert "_device_ref" in buffers
+    assert buffers["_device_ref"].numel() == 0
+    assert buffers["_device_ref"].device == torch.device("cpu")
+    assert "_device_ref" not in obj.state_dict()
+    assert not hasattr(obj, "_device_str")
+    assert obj.device == "cpu"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_to_cuda_updates_device_property_from_buffer():
+    obj = Object(device="cpu")
+
+    obj.to("cuda:0")
+
+    assert obj.device == "cuda:0"
+    assert obj._device_ref.device == torch.device("cuda:0")
+    assert obj.torch_rng == config.torch_rng("cuda:0")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_to_cuda_moves_registered_non_persistent_buffers():
+    obj = _BufferObject(device="cpu")
+
+    obj.to("cuda:0")
+
+    assert obj.device == "cuda:0"
+    assert obj._cache.device == torch.device("cuda:0")
+    assert "_cache" not in obj.state_dict()
 
 
 def test_convert(precision, device):


### PR DESCRIPTION
Fixes #1167

## Description

This PR fixes device migration behavior for `sionna.phy` modules that keep logical device state, cached tensors, or precomputed tensor state outside PyTorch's normal parameter/buffer migration path.

Previously, after constructing a PHY module on CPU and then calling `.to(cuda_device)`, some internal state could remain on the original device. This could leave `Object.device` stale, keep cached tensors on the wrong device, or produce CPU outputs for CUDA inputs in affected modules.

The fix makes device-dependent internal state follow PyTorch module migration semantics while preserving trainable `torch.nn.Parameter` inputs where applicable.

## Changes

- Derive `Object.device` from a non-persistent `_device_ref` buffer instead of a plain string field.
- Register precomputed and cached tensors as non-persistent buffers across affected PHY components.
- Convert `Trellis` into a `torch.nn.Module` so its transition tensors participate in `.to(...)` migration.
- Preserve trainable `Parameter` inputs for custom constellation points, filter coefficients, and window coefficients.
- Update affected areas including channel, mapping, signal, MIMO, OFDM, FEC, and NR components.
- Add regression tests for device migration and trainable-parameter preservation.

## Tests

- `git diff --check main..HEAD`
- Full unit test suite was previously run on an earlier version of this fix on a CUDA-enabled Ubuntu machine:
  - OS: Ubuntu 24.04.3 LTS
  - GPU: NVIDIA RTX A4000
  - NVIDIA driver: 535.288.01
  - Python: 3.12.13
  - PyTorch: 2.11.0+cu126
  - pytest: 9.0.3
  - Result: `3901 passed, 34 skipped, 40 warnings in 6:32:37`
